### PR TITLE
chore(typings): Add reconnecting websocket handler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -186,15 +186,17 @@ declare module 'binance-api-node' {
     }
 
     export interface WebSocket {
-        depth: (pair: string | string[], callback: (depth: Depth) => void) => Function;
-        partialDepth: (options: { symbol: string, level: number } | { symbol: string, level: number }[], callback: (depth: PartialDepth) => void) => Function;
-        ticker: (pair: string | string[], callback: (ticker: Ticker) => void) => Function;
-        allTickers: (callback: (tickers: Ticker[]) => void) => Function;
-        candles: (pair: string | string[], period: string, callback: (ticker: Candle) => void) => Function;
-        trades: (pairs: string | string[], callback: (trade: Trade) => void) => Function;
-        aggTrades: (pairs: string | string[], callback: (trade: Trade) => void) => Function;
+        depth: (pair: string | string[], callback: (depth: Depth) => void) => ReconnectingWebSocketHandler;
+        partialDepth: (options: { symbol: string, level: number } | { symbol: string, level: number }[], callback: (depth: PartialDepth) => void) => ReconnectingWebSocketHandler;
+        ticker: (pair: string | string[], callback: (ticker: Ticker) => void) => ReconnectingWebSocketHandler;
+        allTickers: (callback: (tickers: Ticker[]) => void) => ReconnectingWebSocketHandler;
+        candles: (pair: string | string[], period: string, callback: (ticker: Candle) => void) => ReconnectingWebSocketHandler;
+        trades: (pairs: string | string[], callback: (trade: Trade) => void) => ReconnectingWebSocketHandler;
+        aggTrades: (pairs: string | string[], callback: (trade: Trade) => void) => ReconnectingWebSocketHandler;
         user: (callback: (msg: OutboundAccountInfo | ExecutionReport) => void) => Function;
     }
+
+    export type ReconnectingWebSocketHandler = (options?: {keepClosed: boolean, fastClose: boolean, delay: number}) => void
 
     export type CandleChartInterval =
         | '1m'


### PR DESCRIPTION
All WebSocket endpoints (except `user`) return a handler to control all "Reconnecting WebSocket" instances with their respective [options](https://github.com/pladaria/reconnecting-websocket/tree/v3.2.2#manually-closing).