### PR TITLE
Export charting intervals as enum

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -198,22 +198,23 @@ declare module 'binance-api-node' {
 
     export type ReconnectingWebSocketHandler = (options?: {keepClosed: boolean, fastClose: boolean, delay: number}) => void
 
-    export type CandleChartInterval =
-        | '1m'
-        | '3m'
-        | '5m'
-        | '15m'
-        | '30m'
-        | '1h'
-        | '2h'
-        | '4h'
-        | '6h'
-        | '8h'
-        | '12h'
-        | '1d'
-        | '3d'
-        | '1w'
-        | '1M';
+    export enum CandleChartInterval {
+        ONE_MINUTE = '1m',
+        THREE_MINUTES = '3m',
+        FIVE_MINUTES = '5m',
+        FIFTEEN_MINUTES = '15m',
+        THIRTY_MINUTES = '30m',
+        ONE_HOUR = '1h',
+        TWO_HOURS = '2h',
+        FOUR_HOURS = '4h',
+        SIX_HOURS = '6h',
+        EIGHT_HOURS = '8h',
+        TWELVE_HOURS = '12h',
+        ONE_DAY = '1d',
+        THREE_DAYS = '3d',
+        ONE_WEEK = '1w',
+        ONE_MONTH = '1M'
+    }
 
     export type RateLimitType =
         | 'REQUEST_WEIGHT'


### PR DESCRIPTION
For better reusability I turned the `CandleChartInterval` into an `enum`. This way the `CandleChartInterval` is not just a `string` but a fixed set of values. These values can be reused with statements like `CandleChartInterval.SIX_HOURS`.