### PR TITLE
Add order list ID to account trade list data

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -543,6 +543,7 @@ declare module 'binance-api-node' {
     interface MyTrade {
         id: number;
         orderId: number;
+        orderListId: number;
         price: string;
         qty: string;
         quoteQty: string;


### PR DESCRIPTION
There now is a `orderListId` property.

Reference: https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-trade-list-user_data