### PR TITLE
fix: Export missing enums

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,3 +48,36 @@ export const ErrorCodes = {
   BAD_API_KEY_FMT: -2014,
   REJECTED_MBX_KEY: -2015,
 }
+
+export const CandleChartInterval = {
+  ONE_MINUTE: '1m',
+  THREE_MINUTES: '3m',
+  FIVE_MINUTES: '5m',
+  FIFTEEN_MINUTES: '15m',
+  THIRTY_MINUTES: '30m',
+  ONE_HOUR: '1h',
+  TWO_HOURS: '2h',
+  FOUR_HOURS: '4h',
+  SIX_HOURS: '6h',
+  EIGHT_HOURS: '8h',
+  TWELVE_HOURS: '12h',
+  ONE_DAY: '1d',
+  THREE_DAYS: '3d',
+  ONE_WEEK: '1w',
+  ONE_MONTH: '1M',
+}
+
+export const DepositStatus = {
+  PENDING: 0,
+  SUCCESS: 1,
+}
+
+export const WithdrawStatus = {
+  EMAIL_SENT: 0,
+  CANCELLED: 1,
+  AWAITING_APPROVAL: 2,
+  REJECTED: 3,
+  PROCESSING: 4,
+  FAILURE: 5,
+  COMPLETED: 6,
+}


### PR DESCRIPTION
The [index.dts file](https://github.com/Ashlar/binance-api-node/blob/master/index.d.ts) declares three enums (`CandleChartInterval`, `DepositStatus` & `WithdrawStatus`) which were missing from the export.