### PR TITLE
chore(typings): Mark depositTip as optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -141,7 +141,7 @@ declare module 'binance-api-node' {
         success: boolean,
         assetDetail: {
             [asset: string]: {
-                minWithdrawAmount: string;
+                minWithdrawAmount: number;
                 depositStatus: boolean;
                 withdrawFee: number;
                 withdrawStatus: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -145,7 +145,7 @@ declare module 'binance-api-node' {
                 depositStatus: boolean;
                 withdrawFee: number;
                 withdrawStatus: boolean;
-                depositTip: string;
+                depositTip?: string;
             }
         }
     }


### PR DESCRIPTION
Not every asset has a deposit tip.

Example:

```json
    "BTC": {
      "depositStatus": true,
      "minWithdrawAmount": 0.001,
      "withdrawFee": 0.0005,
      "withdrawStatus": true
    }
```

But some do have:

```json
    "BTM": {
      "depositStatus": false,
      "depositTip": "Delisted, Deposit Suspended",
      "minWithdrawAmount": 10,
      "withdrawFee": 5,
      "withdrawStatus": true
    }
```

It can be tested when querying `client.assetDetail()`.