### PR TITLE
fix: Sync trade fee result response

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,10 +61,6 @@ declare module 'binance-api-node' {
         maker: number;
         taker: number;
     }
-    export interface TradeFeeResult {
-        tradeFee: TradeFee[]
-        success: boolean
-    }
     export interface AggregatedTrade {
         aggId: number;
         price: string;
@@ -152,7 +148,7 @@ declare module 'binance-api-node' {
 
     export interface Binance {
         accountInfo(options?: { useServerTime: boolean }): Promise<Account>;
-        tradeFee(): Promise<TradeFeeResult>;
+        tradeFee(): Promise<TradeFee[]>;
         aggTrades(options?: { symbol: string, fromId?: string, startTime?: number, endTime?: number, limit?: number }): Promise<AggregatedTrade[]>;
         allBookTickers(): Promise<{ [key: string]: Ticker }>;
         book(options: { symbol: string, limit?: number }): Promise<OrderBook>;


### PR DESCRIPTION
The official [Binance Trade Fee documentation](https://github.com/binance-exchange/binance-official-api-docs/blob/master/wapi-api.md#trade-fee-user_data) writes that a `TradeFeeResult` will be returned but our library directly returns the [tradeFee property](https://github.com/Ashlar/binance-api-node/blob/0.9.9/src/http-client.js#L266) of it.

Question to @balthazar: The tradeFee function of "http-client" is the only one which does a mapping with `.then(res => res.tradeFee)`. We could also remove this mapping (to be consistent with the rest of the API calls and Binance API documentation) and update the current [README](https://github.com/Ashlar/binance-api-node/tree/0.9.9#tradefee) about "tradeFee". I am in favor of this solution but it is a **BREAKING API CHANGE**, so we might want to increase the version number. Good time to rollout a 1.0! 😏 