### PR TITLE
fix: Keep tradeFee inline with Binance docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,17 +911,21 @@ console.log(await client.tradeFee())
 <summary>Output</summary>
 
 ```js
-[{
-  symbol: 'BTC',
-  maker: 0.0001,
-  taker: 0.0001,
-},
 {
-  symbol: 'LTC',
-  maker: 0.0001,
-  taker: 0.0001,
+  tradeFee: [{
+    symbol: 'BTC',
+    maker: 0.0001,
+    taker: 0.0001,
+  },
+  {
+    symbol: 'LTC',
+    maker: 0.0001,
+    taker: 0.0001,
+  }
+  ...],
+  success: true,
 }
-...]
+
 ```
 
 </details>

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -278,7 +278,7 @@ export default opts => {
     withdrawHistory: payload => privCall('/wapi/v3/withdrawHistory.html', payload),
     depositHistory: payload => privCall('/wapi/v3/depositHistory.html', payload),
     depositAddress: payload => privCall('/wapi/v3/depositAddress.html', payload),
-    tradeFee: payload => privCall('/wapi/v3/tradeFee.html', payload).then(res => res.tradeFee),
+    tradeFee: payload => privCall('/wapi/v3/tradeFee.html', payload),
     assetDetail: payload => privCall('/wapi/v3/assetDetail.html', payload),
 
     getDataStream: () => privCall('/api/v1/userDataStream', null, 'POST', true),

--- a/test/authenticated.js
+++ b/test/authenticated.js
@@ -102,7 +102,7 @@ test('[REST] accountInfo', async t => {
 })
 
 test('[REST] tradeFee', async t => {
-  const tfee = await client.tradeFee()
+  const tfee = (await client.tradeFee()).tradeFee
   t.truthy(tfee)
   t.truthy(tfee.length)
   checkFields(t, tfee[0], ['symbol', 'maker', 'taker'])


### PR DESCRIPTION
As [discussed](https://github.com/Ashlar/binance-api-node/pull/209) this PR will return a payload which is inline with the Binance API docs:
- https://github.com/binance-exchange/binance-official-api-docs/blob/master/wapi-api.md#trade-fee-user_data