### PR TITLE
Futures Support in progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,19 @@ Following examples will use the `await` form, which requires some configuration 
   - [prices](#prices)
   - [allBookTickers](#allbooktickers)
 - [Futures Public REST Endpoints](#futures-public-rest-endpoints)
-  - [ping](#futures-ping)
-  - [time](#futures-time)
-  - [exchangeInfo](#futures-exchangeinfo)
-  - [book](#futures-book)
-  - [candles](#futures-candles)
-  - [aggTrades](#futures-aggtrades)
-  - [trades](#futures-trades)
-  - [dailyStats](#futures-dailystats)
-  - [avgPrice](#futures-avgPrice)
-  - [prices](#futures-prices)
-  - [allBookTickers](#futures-allbooktickers)
+  - [futures ping](#futures-ping)
+  - [futures time](#futures-time)
+  - [futures exchangeInfo](#futures-exchangeinfo)
+  - [futures book](#futures-book)
+  - [futures candles](#futures-candles)
+  - [futures aggTrades](#futures-aggtrades)
+  - [futures trades](#futures-trades)
+  - [futures dailyStats](#futures-dailystats)
+  - [futures avgPrice](#futures-avgPrice)
+  - [futures prices](#futures-prices)
+  - [futures allBookTickers](#futures-allbooktickers)
+  - [futures markPrice](#futures-markPrice)
+  - [futures allForceOrders](#futures-allForceOrders)
 - [Authenticated REST Endpoints](#authenticated-rest-endpoints)
   - [order](#order)
   - [orderTest](#ordertest)
@@ -803,12 +805,12 @@ console.log(await client.futuresMarkPrice())
 
 </details>
 
-#### futures Liquidation Orders
+#### futures AllForceOrders
 
 Get all Liquidation Orders.
 
 ```js
-console.log(await client.futuresMarkPrice())
+console.log(await client.futuresAllForceOrders())
 ```
 
 | Param     | Type   | Required |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const client = Binance()
 const client2 = Binance({
   apiKey: 'xxx',
   apiSecret: 'xxx',
-  getTime: xxx // time generator function, optional, defaults to () => Date.now()
+  getTime: xxx, // time generator function, optional, defaults to () => Date.now()
 })
 
 client.time().then(time => console.log(time))
@@ -44,41 +44,53 @@ Following examples will use the `await` form, which requires some configuration 
 ### Table of Contents
 
 - [Public REST Endpoints](#public-rest-endpoints)
-    - [ping](#ping)
-    - [time](#time)
-    - [exchangeInfo](#exchangeinfo)
-    - [book](#book)
-    - [candles](#candles)
-    - [aggTrades](#aggtrades)
-    - [trades](#trades)
-    - [dailyStats](#dailystats)
-    - [avgPrice](#avgPrice)
-    - [prices](#prices)
-    - [allBookTickers](#allbooktickers)
+  - [ping](#ping)
+  - [time](#time)
+  - [exchangeInfo](#exchangeinfo)
+  - [book](#book)
+  - [candles](#candles)
+  - [aggTrades](#aggtrades)
+  - [trades](#trades)
+  - [dailyStats](#dailystats)
+  - [avgPrice](#avgPrice)
+  - [prices](#prices)
+  - [allBookTickers](#allbooktickers)
+- [Futures Public REST Endpoints](#futures-public-rest-endpoints)
+  - [ping](#futures-ping)
+  - [time](#futures-time)
+  - [exchangeInfo](#futures-exchangeinfo)
+  - [book](#futures-book)
+  - [candles](#futures-candles)
+  - [aggTrades](#futures-aggtrades)
+  - [trades](#futures-trades)
+  - [dailyStats](#futures-dailystats)
+  - [avgPrice](#futures-avgPrice)
+  - [prices](#futures-prices)
+  - [allBookTickers](#futures-allbooktickers)
 - [Authenticated REST Endpoints](#authenticated-rest-endpoints)
-    - [order](#order)
-    - [orderTest](#ordertest)
-    - [getOrder](#getorder)
-    - [cancelOrder](#cancelorder)
-    - [openOrders](#openorders)
-    - [allOrders](#allorders)
-    - [accountInfo](#accountinfo)
-    - [myTrades](#mytrades)
-    - [tradesHistory](#tradeshistory)
-    - [depositHistory](#deposithistory)
-    - [withdrawHistory](#withdrawhistory)
-    - [withdraw](#withdraw)
-    - [depositAddress](#depositaddress)
-    - [tradeFee](#tradefee)
+  - [order](#order)
+  - [orderTest](#ordertest)
+  - [getOrder](#getorder)
+  - [cancelOrder](#cancelorder)
+  - [openOrders](#openorders)
+  - [allOrders](#allorders)
+  - [accountInfo](#accountinfo)
+  - [myTrades](#mytrades)
+  - [tradesHistory](#tradeshistory)
+  - [depositHistory](#deposithistory)
+  - [withdrawHistory](#withdrawhistory)
+  - [withdraw](#withdraw)
+  - [depositAddress](#depositaddress)
+  - [tradeFee](#tradefee)
 - [Websockets](#websockets)
-    - [depth](#depth)
-    - [partialDepth](#partialdepth)
-    - [ticker](#ticker)
-    - [allTickers](#alltickers)
-    - [candles](#candles-1)
-    - [aggTrades](#aggtrades-1)
-    - [trades](#trades-1)
-    - [user](#user)
+  - [depth](#depth)
+  - [partialDepth](#partialdepth)
+  - [ticker](#ticker)
+  - [allTickers](#alltickers)
+  - [candles](#candles-1)
+  - [aggTrades](#aggtrades-1)
+  - [trades](#trades-1)
+  - [user](#user)
 - [ErrorCodes](#errorcodes)
 
 ### Public REST Endpoints
@@ -181,10 +193,10 @@ Get the order book for a symbol.
 console.log(await client.book({ symbol: 'ETHBTC' }))
 ```
 
-|Param|Type|Required|Default|
-|--- |--- |--- |--- |
-|symbol|String|true|
-|limit|Number|false|`100`|
+| Param  | Type   | Required | Default |
+| ------ | ------ | -------- | ------- |
+| symbol | String | true     |
+| limit  | Number | false    | `100`   |
 
 <details>
 <summary>Output</summary>
@@ -215,30 +227,32 @@ Retrieves Candlestick for a symbol. Candlesticks are uniquely identified by thei
 console.log(await client.candles({ symbol: 'ETHBTC' }))
 ```
 
-|Param|Type|Required|Default|Description|
-|--- |--- |--- |--- |--- |
-|symbol|String|true|
-|interval|String|false|`5m`|`1m`, `3m`, `5m`, `15m`, `30m`, `1h`, `2h`,<br>`4h`, `6h`, `8h`, `12h`, `1d`, `3d`, `1w`, `1M`|
-|limit|Number|false|`500`|Max `1000`|
-|startTime|Number|false|
-|endTime|Number|false|
+| Param     | Type   | Required | Default | Description                                                                                    |
+| --------- | ------ | -------- | ------- | ---------------------------------------------------------------------------------------------- |
+| symbol    | String | true     |
+| interval  | String | false    | `5m`    | `1m`, `3m`, `5m`, `15m`, `30m`, `1h`, `2h`,<br>`4h`, `6h`, `8h`, `12h`, `1d`, `3d`, `1w`, `1M` |
+| limit     | Number | false    | `500`   | Max `1000`                                                                                     |
+| startTime | Number | false    |
+| endTime   | Number | false    |
 
 <details>
 <summary>Output</summary>
 
 ```js
-[{
-  openTime: 1508328900000,
-  open: '0.05655000',
-  high: '0.05656500',
-  low: '0.05613200',
-  close: '0.05632400',
-  volume: '68.88800000',
-  closeTime: 1508329199999,
-  quoteAssetVolume: '2.29500857',
-  trades: 85,
-  baseAssetVolume: '40.61900000'
-}]
+;[
+  {
+    openTime: 1508328900000,
+    open: '0.05655000',
+    high: '0.05656500',
+    low: '0.05613200',
+    close: '0.05632400',
+    volume: '68.88800000',
+    closeTime: 1508329199999,
+    quoteAssetVolume: '2.29500857',
+    trades: 85,
+    baseAssetVolume: '40.61900000',
+  },
+]
 ```
 
 </details>
@@ -251,13 +265,13 @@ Get compressed, aggregate trades. Trades that fill at the time, from the same or
 console.log(await client.aggTrades({ symbol: 'ETHBTC' }))
 ```
 
-|Param|Type|Required|Default|Description|
-|--- |--- |--- |--- |--- |
-|symbol|String|true|
-|fromId|String|false||ID to get aggregate trades from INCLUSIVE.|
-|startTime|Number|false||Timestamp in ms to get aggregate trades from INCLUSIVE.
-|endTime|Number|false||Timestamp in ms to get aggregate trades until INCLUSIVE.|
-|limit|Number|false|`500`|Max `500`|
+| Param     | Type   | Required | Default | Description                                              |
+| --------- | ------ | -------- | ------- | -------------------------------------------------------- |
+| symbol    | String | true     |
+| fromId    | String | false    |         | ID to get aggregate trades from INCLUSIVE.               |
+| startTime | Number | false    |         | Timestamp in ms to get aggregate trades from INCLUSIVE.  |
+| endTime   | Number | false    |         | Timestamp in ms to get aggregate trades until INCLUSIVE. |
+| limit     | Number | false    | `500`   | Max `500`                                                |
 
 Note: If both `startTime` and `endTime` are sent, `limit` should not be sent AND the distance between `startTime` and `endTime` must be less than 24 hours.
 
@@ -267,16 +281,18 @@ Note: If `frondId`, `startTime`, and `endTime` are not sent, the most recent agg
 <summary>Output</summary>
 
 ```js
-[{
-  aggId: 2107132,
-  price: '0.05390400',
-  quantity: '1.31000000',
-  firstId: 2215345,
-  lastId: 2215345,
-  timestamp: 1508478599481,
-  isBuyerMaker: true,
-  wasBestPrice: true
-}]
+;[
+  {
+    aggId: 2107132,
+    price: '0.05390400',
+    quantity: '1.31000000',
+    firstId: 2215345,
+    lastId: 2215345,
+    timestamp: 1508478599481,
+    isBuyerMaker: true,
+    wasBestPrice: true,
+  },
+]
 ```
 
 </details>
@@ -289,24 +305,24 @@ Get recent trades of a symbol.
 console.log(await client.trades({ symbol: 'ETHBTC' }))
 ```
 
-|Param|Type|Required|Default|Description|
-|--- |--- |--- |--- |--- |
-|symbol|String|true|
-|limit|Number|false|`500`|Max `500`|
+| Param  | Type   | Required | Default | Description |
+| ------ | ------ | -------- | ------- | ----------- |
+| symbol | String | true     |
+| limit  | Number | false    | `500`   | Max `500`   |
 
 <details>
 <summary>Output</summary>
 
 ```js
-[
+;[
   {
-    "id": 28457,
-    "price": "4.00000100",
-    "qty": "12.00000000",
-    "time": 1499865549590,
-    "isBuyerMaker": true,
-    "isBestMatch": true
-  }
+    id: 28457,
+    price: '4.00000100',
+    qty: '12.00000000',
+    time: 1499865549590,
+    isBuyerMaker: true,
+    isBestMatch: true,
+  },
 ]
 ```
 
@@ -320,9 +336,9 @@ console.log(await client.trades({ symbol: 'ETHBTC' }))
 console.log(await client.dailyStats({ symbol: 'ETHBTC' }))
 ```
 
-|Param|Type|Required|
-|--- |--- |--- |
-|symbol|String|false|
+| Param  | Type   | Required |
+| ------ | ------ | -------- |
+| symbol | String | false    |
 
 <details>
 <summary>Output</summary>
@@ -433,6 +449,397 @@ console.log(await client.allBookTickers())
 
 </details>
 
+#### futures ping
+
+Test connectivity to the API.
+
+```js
+console.log(await client.futuresPing())
+```
+
+#### futures time
+
+Test connectivity to the Rest API and get the current server time.
+
+```js
+console.log(await client.futuresTime())
+```
+
+<details>
+<summary>Output</summary>
+
+```js
+1508478457643
+```
+
+</details>
+
+#### futures exchangeInfo
+
+Get the current exchange trading rules and symbol information.
+
+```js
+console.log(await client.futuresExchangeInfo())
+```
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  "timezone": "UTC",
+  "serverTime": 1508631584636,
+  "rateLimits": [
+    {
+      "rateLimitType": "REQUEST_WEIGHT",
+      "interval": "MINUTE",
+      "intervalNum": 1,
+      "limit": 1200
+    },
+    {
+      "rateLimitType": "ORDERS",
+      "interval": "SECOND",
+      "intervalNum": 1,
+      "limit": 10
+    },
+    {
+      "rateLimitType": "ORDERS",
+      "interval": "DAY",
+      "intervalNum": 1,
+      "limit": 100000
+    }
+  ],
+  "exchangeFilters": [],
+  "symbols": [...]
+}
+```
+
+</details>
+
+#### futures book
+
+Get the order book for a symbol.
+
+```js
+console.log(await client.futuresBook({ symbol: 'BTCUSDT' }))
+```
+
+| Param  | Type   | Required | Default |
+| ------ | ------ | -------- | ------- |
+| symbol | String | true     |
+| limit  | Number | false    | `100`   |
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  lastUpdateId: 17647759,
+  asks:
+   [
+     { price: '8000.05411500', quantity: '54.55000000' },
+     { price: '8000.05416700', quantity: '1111.80100000' }
+   ],
+  bids:
+   [
+     { price: '8000.05395500', quantity: '223.70000000' },
+     { price: '8000.05395100', quantity: '1134.84100000' }
+   ]
+}
+```
+
+</details>
+
+#### futures candles
+
+Retrieves Candlestick for a symbol. Candlesticks are uniquely identified by their open time.
+
+```js
+console.log(await client.futuresCandles({ symbol: 'BTCUSDT' }))
+```
+
+| Param     | Type   | Required | Default | Description                                                                                    |
+| --------- | ------ | -------- | ------- | ---------------------------------------------------------------------------------------------- |
+| symbol    | String | true     |
+| interval  | String | false    | `5m`    | `1m`, `3m`, `5m`, `15m`, `30m`, `1h`, `2h`,<br>`4h`, `6h`, `8h`, `12h`, `1d`, `3d`, `1w`, `1M` |
+| limit     | Number | false    | `500`   | Max `1000`                                                                                     |
+| startTime | Number | false    |
+| endTime   | Number | false    |
+
+<details>
+<summary>Output</summary>
+
+```js
+;[
+  {
+    openTime: 1508328900000,
+    open: '0.05655000',
+    high: '0.05656500',
+    low: '0.05613200',
+    close: '0.05632400',
+    volume: '68.88800000',
+    closeTime: 1508329199999,
+    quoteAssetVolume: '2.29500857',
+    trades: 85,
+    baseAssetVolume: '40.61900000',
+  },
+]
+```
+
+</details>
+
+#### futures aggTrades
+
+Get compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.
+
+```js
+console.log(await client.futuresAggTrades({ symbol: 'ETHBTC' }))
+```
+
+| Param     | Type   | Required | Default | Description                                              |
+| --------- | ------ | -------- | ------- | -------------------------------------------------------- |
+| symbol    | String | true     |
+| fromId    | String | false    |         | ID to get aggregate trades from INCLUSIVE.               |
+| startTime | Number | false    |         | Timestamp in ms to get aggregate trades from INCLUSIVE.  |
+| endTime   | Number | false    |         | Timestamp in ms to get aggregate trades until INCLUSIVE. |
+| limit     | Number | false    | `500`   | Max `500`                                                |
+
+Note: If both `startTime` and `endTime` are sent, `limit` should not be sent AND the distance between `startTime` and `endTime` must be less than 24 hours.
+
+Note: If `frondId`, `startTime`, and `endTime` are not sent, the most recent aggregate trades will be returned.
+
+<details>
+<summary>Output</summary>
+
+```js
+;[
+  {
+    aggId: 2107132,
+    price: '0.05390400',
+    quantity: '1.31000000',
+    firstId: 2215345,
+    lastId: 2215345,
+    timestamp: 1508478599481,
+    isBuyerMaker: true,
+    wasBestPrice: true,
+  },
+]
+```
+
+</details>
+
+#### futures trades
+
+Get recent trades of a symbol.
+
+```js
+console.log(await client.futuresTrades({ symbol: 'ETHBTC' }))
+```
+
+| Param  | Type   | Required | Default | Description |
+| ------ | ------ | -------- | ------- | ----------- |
+| symbol | String | true     |
+| limit  | Number | false    | `500`   | Max `500`   |
+
+<details>
+<summary>Output</summary>
+
+```js
+;[
+  {
+    id: 28457,
+    price: '4.00000100',
+    qty: '12.00000000',
+    time: 1499865549590,
+    isBuyerMaker: true,
+    isBestMatch: true,
+  },
+]
+```
+
+</details>
+
+#### futures dailyStats
+
+24 hour price change statistics, not providing a symbol will return all tickers and is resource-expensive.
+
+```js
+console.log(await client.futuresDailyStats({ symbol: 'ETHBTC' }))
+```
+
+| Param  | Type   | Required |
+| ------ | ------ | -------- |
+| symbol | String | false    |
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  symbol: 'BTCUSDT',
+  priceChange: '-0.00112000',
+  priceChangePercent: '-1.751',
+  weightedAvgPrice: '0.06324784',
+  prevClosePrice: '0.06397400',
+  lastPrice: '0.06285500',
+  lastQty: '0.63500000',
+  bidPrice: '0.06285500',
+  bidQty: '0.81900000',
+  askPrice: '0.06291900',
+  askQty: '2.93800000',
+  openPrice: '0.06397500',
+  highPrice: '0.06419100',
+  lowPrice: '0.06205300',
+  volume: '126240.37200000',
+  quoteVolume: '7984.43091340',
+  openTime: 1521622289427,
+  closeTime: 1521708689427,
+  firstId: 45409308, // First tradeId
+  lastId: 45724293, // Last tradeId
+  count: 314986 // Trade count
+}
+```
+
+</details>
+
+#### futures avgPrice
+
+Current average price for a symbol.
+
+```js
+console.log(await client.futuresAvgPrice({ symbol: 'ETHBTC' }))
+```
+
+| Param  | Type   | Required |
+| ------ | ------ | -------- |
+| symbol | String | true     |
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  "mins": 5,
+  "price": "9.35751834"
+}
+```
+
+</details>
+
+#### futures prices
+
+Latest price for all symbols.
+
+```js
+console.log(await client.futuresPrices())
+```
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  BTCUSDT: '8590.05392500',
+  ETHUSDT: '154.1100',
+  ...
+}
+```
+
+</details>
+
+#### futures allBookTickers
+
+Best price/qty on the order book for all symbols.
+
+```js
+console.log(await client.futuresAllBookTickers())
+```
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  BTCUSDT: {
+    symbol: 'BTCUSDT',
+    bidPrice: '0.04890400',
+    bidQty: '0.74100000',
+    askPrice: '0.05230000',
+    askQty: '0.79900000'
+  },
+  ETHUSDT: {
+    symbol: 'ETHUSDT',
+    bidPrice: '0.89582000',
+    bidQty: '0.63300000',
+    askPrice: '1.02328000',
+    askQty: '0.99900000'
+  }
+  ...
+}
+```
+
+</details>
+
+#### futures markPrice
+
+Mark Price and Funding Rate.
+
+```js
+console.log(await client.futuresMarkPrice())
+```
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+    "symbol": "BTCUSDT",
+    "markPrice": "11012.80409769",
+    "lastFundingRate": "-0.03750000",
+    "nextFundingTime": 1562569200000,
+    "time": 1562566020000
+}
+```
+
+</details>
+
+#### futures Liquidation Orders
+
+Get all Liquidation Orders.
+
+```js
+console.log(await client.futuresMarkPrice())
+```
+
+| Param     | Type   | Required |
+| --------- | ------ | -------- |
+| symbol    | String | false    |
+| startTime | Long   | false    |
+| endTime   | Long   | false    |
+| limit     | Long   | false    |
+
+<details>
+<summary>Output</summary>
+
+```js
+;[
+  {
+    symbol: 'BTCUSDT', // SYMBOL
+    price: '7918.33', // ORDER_PRICE
+    origQty: '0.014', // ORDER_AMOUNT
+    executedQty: '0.014', // FILLED_AMOUNT
+    avragePrice: '7918.33', // AVG_PRICE
+    status: 'FILLED', // STATUS
+    timeInForce: 'IOC', // TIME_IN_FORCE
+    type: 'LIMIT',
+    side: 'SELL', // DIRECTION
+    time: 1568014460893,
+  },
+]
+```
+
+</details>
+
 ### Authenticated REST Endpoints
 
 Note that for all authenticated endpoints, you can pass an extra parameter
@@ -444,44 +851,46 @@ the request.
 Creates a new order.
 
 ```js
-console.log(await client.order({
-  symbol: 'XLMETH',
-  side: 'BUY',
-  quantity: 100,
-  price: 0.0002,
-}))
+console.log(
+  await client.order({
+    symbol: 'XLMETH',
+    side: 'BUY',
+    quantity: 100,
+    price: 0.0002,
+  }),
+)
 ```
 
-|Param|Type|Required|Default|Description|
-|--- |--- |--- |--- |--- |
-|symbol|String|true|
-|side|String|true||`BUY`,`SELL`|
-|type|String|false|`LIMIT`|`LIMIT`, `MARKET`|
-|quantity|Number|true|
-|price|Number|true||Optional for `MARKET` orders|
-|timeInForce|String|false|`GTC`|`FOK`, `GTC`, `IOC`|
-|newClientOrderId|String|false||A unique id for the order. Automatically generated if not sent.|
-|stopPrice|Number|false||Used with stop orders|
-|newOrderRespType|String|false|`RESULT`|Returns more complete info of the order. `ACK`, `RESULT`, or `FULL`|
-|icebergQty|Number|false||Used with iceberg orders|
-|recvWindow|Number|false|
+| Param            | Type   | Required | Default  | Description                                                         |
+| ---------------- | ------ | -------- | -------- | ------------------------------------------------------------------- |
+| symbol           | String | true     |
+| side             | String | true     |          | `BUY`,`SELL`                                                        |
+| type             | String | false    | `LIMIT`  | `LIMIT`, `MARKET`                                                   |
+| quantity         | Number | true     |
+| price            | Number | true     |          | Optional for `MARKET` orders                                        |
+| timeInForce      | String | false    | `GTC`    | `FOK`, `GTC`, `IOC`                                                 |
+| newClientOrderId | String | false    |          | A unique id for the order. Automatically generated if not sent.     |
+| stopPrice        | Number | false    |          | Used with stop orders                                               |
+| newOrderRespType | String | false    | `RESULT` | Returns more complete info of the order. `ACK`, `RESULT`, or `FULL` |
+| icebergQty       | Number | false    |          | Used with iceberg orders                                            |
+| recvWindow       | Number | false    |
 
 Additional mandatory parameters based on `type`:
 
-Type | Additional mandatory parameters
------------- | ------------
-`LIMIT` | `timeInForce`, `quantity`, `price`
-`MARKET` | `quantity`
-`STOP_LOSS` | `quantity`, `stopPrice`
-`STOP_LOSS_LIMIT` | `timeInForce`, `quantity`,  `price`, `stopPrice`
-`TAKE_PROFIT` | `quantity`, `stopPrice`
-`TAKE_PROFIT_LIMIT` | `timeInForce`, `quantity`, `price`, `stopPrice`
-`LIMIT_MAKER` | `quantity`, `price`
+| Type                | Additional mandatory parameters                 |
+| ------------------- | ----------------------------------------------- |
+| `LIMIT`             | `timeInForce`, `quantity`, `price`              |
+| `MARKET`            | `quantity`                                      |
+| `STOP_LOSS`         | `quantity`, `stopPrice`                         |
+| `STOP_LOSS_LIMIT`   | `timeInForce`, `quantity`, `price`, `stopPrice` |
+| `TAKE_PROFIT`       | `quantity`, `stopPrice`                         |
+| `TAKE_PROFIT_LIMIT` | `timeInForce`, `quantity`, `price`, `stopPrice` |
+| `LIMIT_MAKER`       | `quantity`, `price`                             |
 
-* `LIMIT_MAKER` are `LIMIT` orders that will be rejected if they would immediately match and trade as a taker.
-* `STOP_LOSS` and `TAKE_PROFIT` will execute a `MARKET` order when the `stopPrice` is reached.
-* Any `LIMIT` or `LIMIT_MAKER` type order can be made an iceberg order by sending an `icebergQty`.
-* Any order with an `icebergQty` MUST have `timeInForce` set to `GTC`.
+- `LIMIT_MAKER` are `LIMIT` orders that will be rejected if they would immediately match and trade as a taker.
+- `STOP_LOSS` and `TAKE_PROFIT` will execute a `MARKET` order when the `stopPrice` is reached.
+- Any `LIMIT` or `LIMIT_MAKER` type order can be made an iceberg order by sending an `icebergQty`.
+- Any order with an `icebergQty` MUST have `timeInForce` set to `GTC`.
 
 <details>
 <summary>Output</summary>
@@ -515,18 +924,20 @@ Same API as above, but does not return any output on success.
 Check an order's status.
 
 ```js
-console.log(await client.getOrder({
-  symbol: 'BNBETH',
-  orderId: 50167927,
-}))
+console.log(
+  await client.getOrder({
+    symbol: 'BNBETH',
+    orderId: 50167927,
+  }),
+)
 ```
 
-|Param|Type|Required|Description|
-|--- |--- |--- |--- |
-|symbol|String|true|
-|orderId|Number|true|Not required if `origClientOrderId` is used|
-|origClientOrderId|String|false|
-|recvWindow|Number|false|
+| Param             | Type   | Required | Description                                 |
+| ----------------- | ------ | -------- | ------------------------------------------- |
+| symbol            | String | true     |
+| orderId           | Number | true     | Not required if `origClientOrderId` is used |
+| origClientOrderId | String | false    |
+| recvWindow        | Number | false    |
 
 <details>
 <summary>Output</summary>
@@ -560,19 +971,21 @@ console.log(await client.getOrder({
 Cancels an active order.
 
 ```js
-console.log(await client.cancelOrder({
-  symbol: 'ETHBTC',
-  orderId: 1,
-}))
+console.log(
+  await client.cancelOrder({
+    symbol: 'ETHBTC',
+    orderId: 1,
+  }),
+)
 ```
 
-|Param|Type|Required|Description|
-|--- |--- |--- |--- |
-|symbol|String|true|
-|orderId|Number|true|Not required if `origClientOrderId` is used|
-|origClientOrderId|String|false|
-|newClientOrderId|String|false|Used to uniquely identify this cancel. Automatically generated by default.|
-|recvWindow|Number|false|
+| Param             | Type   | Required | Description                                                                |
+| ----------------- | ------ | -------- | -------------------------------------------------------------------------- |
+| symbol            | String | true     |
+| orderId           | Number | true     | Not required if `origClientOrderId` is used                                |
+| origClientOrderId | String | false    |
+| newClientOrderId  | String | false    | Used to uniquely identify this cancel. Automatically generated by default. |
+| recvWindow        | Number | false    |
 
 <details>
 <summary>Output</summary>
@@ -593,36 +1006,40 @@ console.log(await client.cancelOrder({
 Get all open orders on a symbol.
 
 ```js
-console.log(await client.openOrders({
-  symbol: 'XLMBTC',
-}))
+console.log(
+  await client.openOrders({
+    symbol: 'XLMBTC',
+  }),
+)
 ```
 
-|Param|Type|Required|
-|--- |--- |--- |
-|symbol|String|true|
-|recvWindow|Number|false|
+| Param      | Type   | Required |
+| ---------- | ------ | -------- |
+| symbol     | String | true     |
+| recvWindow | Number | false    |
 
 <details>
 <summary>Output</summary>
 
 ```js
-[{
-  symbol: 'XLMBTC',
-  orderId: 11271740,
-  clientOrderId: 'ekHkROfW98gBN80LTfufQZ',
-  price: '0.00001081',
-  origQty: '1331.00000000',
-  executedQty: '0.00000000',
-  status: 'NEW',
-  timeInForce: 'GTC',
-  type: 'LIMIT',
-  side: 'BUY',
-  stopPrice: '0.00000000',
-  icebergQty: '0.00000000',
-  time: 1522682290485,
-  isWorking: true
-}]
+;[
+  {
+    symbol: 'XLMBTC',
+    orderId: 11271740,
+    clientOrderId: 'ekHkROfW98gBN80LTfufQZ',
+    price: '0.00001081',
+    origQty: '1331.00000000',
+    executedQty: '0.00000000',
+    status: 'NEW',
+    timeInForce: 'GTC',
+    type: 'LIMIT',
+    side: 'BUY',
+    stopPrice: '0.00000000',
+    icebergQty: '0.00000000',
+    time: 1522682290485,
+    isWorking: true,
+  },
+]
 ```
 
 </details>
@@ -632,38 +1049,42 @@ console.log(await client.openOrders({
 Get all account orders on a symbol; active, canceled, or filled.
 
 ```js
-console.log(await client.allOrders({
-  symbol: 'ETHBTC',
-}))
+console.log(
+  await client.allOrders({
+    symbol: 'ETHBTC',
+  }),
+)
 ```
 
-|Param|Type|Required|Default|Description|
-|--- |--- |--- |--- |--- |
-|symbol|String|true|
-|orderId|Number|false||If set, it will get orders >= that orderId. Otherwise most recent orders are returned.|
-|limit|Number|false|`500`|Max `500`|
-|recvWindow|Number|false|
+| Param      | Type   | Required | Default | Description                                                                            |
+| ---------- | ------ | -------- | ------- | -------------------------------------------------------------------------------------- |
+| symbol     | String | true     |
+| orderId    | Number | false    |         | If set, it will get orders >= that orderId. Otherwise most recent orders are returned. |
+| limit      | Number | false    | `500`   | Max `500`                                                                              |
+| recvWindow | Number | false    |
 
 <details>
 <summary>Output</summary>
 
 ```js
-[{
-  symbol: 'ENGETH',
-  orderId: 191938,
-  clientOrderId: '1XZTVBTGS4K1e',
-  price: '0.00138000',
-  origQty: '1.00000000',
-  executedQty: '1.00000000',
-  status: 'FILLED',
-  timeInForce: 'GTC',
-  type: 'LIMIT',
-  side: 'SELL',
-  stopPrice: '0.00000000',
-  icebergQty: '0.00000000',
-  time: 1508611114735,
-  isWorking: true
-}]
+;[
+  {
+    symbol: 'ENGETH',
+    orderId: 191938,
+    clientOrderId: '1XZTVBTGS4K1e',
+    price: '0.00138000',
+    origQty: '1.00000000',
+    executedQty: '1.00000000',
+    status: 'FILLED',
+    timeInForce: 'GTC',
+    type: 'LIMIT',
+    side: 'SELL',
+    stopPrice: '0.00000000',
+    icebergQty: '0.00000000',
+    time: 1508611114735,
+    isWorking: true,
+  },
+]
 ```
 
 </details>
@@ -676,9 +1097,9 @@ Get current account information.
 console.log(await client.accountInfo())
 ```
 
-|Param|Type|Required|
-|--- |--- |--- |
-|recvWindow|Number|false|
+| Param      | Type   | Required |
+| ---------- | ------ | -------- |
+| recvWindow | Number | false    |
 
 <details>
 <summary>Output</summary>
@@ -706,34 +1127,38 @@ console.log(await client.accountInfo())
 Get trades for the current authenticated account and symbol.
 
 ```js
-console.log(await client.myTrades({
-  symbol: 'ETHBTC',
-}))
+console.log(
+  await client.myTrades({
+    symbol: 'ETHBTC',
+  }),
+)
 ```
 
-|Param|Type|Required|Default|Description|
-|--- |--- |--- |--- |--- |
-|symbol|String|true|
-|limit|Number|false|`500`|Max `500`|
-|fromId|Number|false||TradeId to fetch from. Default gets most recent trades.|
-|recvWindow|Number|false|
+| Param      | Type   | Required | Default | Description                                             |
+| ---------- | ------ | -------- | ------- | ------------------------------------------------------- |
+| symbol     | String | true     |
+| limit      | Number | false    | `500`   | Max `500`                                               |
+| fromId     | Number | false    |         | TradeId to fetch from. Default gets most recent trades. |
+| recvWindow | Number | false    |
 
 <details>
 <summary>Output</summary>
 
 ```js
-[{
-  id: 9960,
-  orderId: 191939,
-  price: '0.00138000',
-  qty: '10.00000000',
-  commission: '0.00001380',
-  commissionAsset: 'ETH',
-  time: 1508611114735,
-  isBuyer: false,
-  isMaker: false,
-  isBestMatch: true
-}]
+;[
+  {
+    id: 9960,
+    orderId: 191939,
+    price: '0.00138000',
+    qty: '10.00000000',
+    commission: '0.00001380',
+    commissionAsset: 'ETH',
+    time: 1508611114735,
+    isBuyer: false,
+    isMaker: false,
+    isBestMatch: true,
+  },
+]
 ```
 
 </details>
@@ -746,25 +1171,25 @@ Lookup symbol trades history.
 console.log(await client.tradesHistory({ symbol: 'ETHBTC' }))
 ```
 
-|Param|Type|Required|Default|Description|
-|--- |--- |--- |--- |--- |
-|symbol|String|true|
-|limit|Number|false|`500`|Max `500`|
-|fromId|Number|false|`null`|TradeId to fetch from. Default gets most recent trades.|
+| Param  | Type   | Required | Default | Description                                             |
+| ------ | ------ | -------- | ------- | ------------------------------------------------------- |
+| symbol | String | true     |
+| limit  | Number | false    | `500`   | Max `500`                                               |
+| fromId | Number | false    | `null`  | TradeId to fetch from. Default gets most recent trades. |
 
 <details>
 <summary>Output</summary>
 
 ```js
-[
+;[
   {
-    "id": 28457,
-      "price": "4.00000100",
-      "qty": "12.00000000",
-      "time": 1499865549590,
-      "isBuyerMaker": true,
-      "isBestMatch": true
-  }
+    id: 28457,
+    price: '4.00000100',
+    qty: '12.00000000',
+    time: 1499865549590,
+    isBuyerMaker: true,
+    isBestMatch: true,
+  },
 ]
 ```
 
@@ -778,13 +1203,13 @@ Get the account deposit history.
 console.log(await client.depositHistory())
 ```
 
-|Param|Type|Required|Description|
-|--- |--- |--- |--- |
-|asset|String|false|
-|status|Number|false|0 (0: pending, 1: success)|
-|startTime|Number|false|
-|endTime|Number|false|
-|recvWindow|Number|false|
+| Param      | Type   | Required | Description                |
+| ---------- | ------ | -------- | -------------------------- |
+| asset      | String | false    |
+| status     | Number | false    | 0 (0: pending, 1: success) |
+| startTime  | Number | false    |
+| endTime    | Number | false    |
+| recvWindow | Number | false    |
 
 <details>
 <summary>Output</summary>
@@ -813,13 +1238,13 @@ Get the account withdraw history.
 console.log(await client.withdrawHistory())
 ```
 
-|Param|Type|Required|Description|
-|--- |--- |--- |--- |
-|asset|String|false|
-|status|Number|false|0 (0: Email Sent, 1: Cancelled 2: Awaiting Approval, 3: Rejected, 4: Processing, 5: Failure, 6: Completed)|
-|startTime|Number|false|
-|endTime|Number|false|
-|recvWindow|Number|false|
+| Param      | Type   | Required | Description                                                                                                |
+| ---------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------- |
+| asset      | String | false    |
+| status     | Number | false    | 0 (0: Email Sent, 1: Cancelled 2: Awaiting Approval, 3: Rejected, 4: Processing, 5: Failure, 6: Completed) |
+| startTime  | Number | false    |
+| endTime    | Number | false    |
+| recvWindow | Number | false    |
 
 <details>
 <summary>Output</summary>
@@ -843,23 +1268,25 @@ console.log(await client.withdrawHistory())
 
 #### withdraw
 
-Triggers the withdraw process (*untested for now*).
+Triggers the withdraw process (_untested for now_).
 
 ```js
-console.log(await client.withdraw({
-  asset: 'ETH',
-  address: '0xfa97c22a03d8522988c709c24283c0918a59c795',
-  amount: 100,
-}))
+console.log(
+  await client.withdraw({
+    asset: 'ETH',
+    address: '0xfa97c22a03d8522988c709c24283c0918a59c795',
+    amount: 100,
+  }),
+)
 ```
 
-|Param|Type|Required|Description|
-|--- |--- |--- |--- |
-|asset|String|true|
-|address|String|true|
-|amount|Number|true|
-|name|String|false|Description of the address|
-|recvWindow|Number|false|
+| Param      | Type   | Required | Description                |
+| ---------- | ------ | -------- | -------------------------- |
+| asset      | String | true     |
+| address    | String | true     |
+| amount     | Number | true     |
+| name       | String | false    | Description of the address |
+| recvWindow | Number | false    |
 
 <details>
 <summary>Output</summary>
@@ -881,9 +1308,9 @@ Retrieve the account deposit address for a specific asset.
 console.log(await client.depositAddress({ asset: 'NEO' }))
 ```
 
-|Param|Type|Required|Description|
-|--- |--- |--- |--- |
-|asset|String|true|The asset name|
+| Param | Type   | Required | Description    |
+| ----- | ------ | -------- | -------------- |
+| asset | String | true     | The asset name |
 
 <details>
 <summary>Output</summary>
@@ -929,7 +1356,6 @@ console.log(await client.tradeFee())
 ```
 
 </details>
-
 
 ### WebSockets
 

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -32,7 +32,7 @@ const sendResult = call =>
     // For API errors the response will be valid JSON,but for proxy errors
     // it will be HTML
     return res.text().then(text => {
-      let error;
+      let error
       try {
         const json = JSON.parse(text)
         // The body was JSON parseable, assume it is an API response error
@@ -76,11 +76,16 @@ const checkParams = (name, payload, requires = []) => {
  */
 const publicCall = ({ endpoints }) => (path, data, method = 'GET', headers = {}) =>
   sendResult(
-    fetch(`${!path.includes('/fapi') ? endpoints.base : endpoints.futures}${path}${makeQueryString(data)}`, {
-      method,
-      json: true,
-      headers,
-    }),
+    fetch(
+      `${!path.includes('/fapi') ? endpoints.base : endpoints.futures}${path}${makeQueryString(
+        data,
+      )}`,
+      {
+        method,
+        json: true,
+        headers,
+      },
+    ),
   )
 
 /**
@@ -138,9 +143,9 @@ const privateCall = ({ apiKey, apiSecret, endpoints, getTime = defaultGetTime, p
 
     return sendResult(
       fetch(
-        `${!path.includes('/fapi') ? endpoints.base : endpoints.futures}${path}${noData
-          ? ''
-          : makeQueryString(newData)}`,
+        `${!path.includes('/fapi') ? endpoints.base : endpoints.futures}${path}${
+          noData ? '' : makeQueryString(newData)
+        }`,
         {
           method,
           headers: { 'X-MBX-APIKEY': apiKey },
@@ -169,9 +174,9 @@ export const candleFields = [
  * Get candles for a specific pair and interval and convert response
  * to a user friendly collection.
  */
-const candles = (pubCall, payload) =>
+const candles = (pubCall, payload, endpoint = '/api/v1/klines') =>
   checkParams('candles', payload, ['symbol']) &&
-  pubCall('/api/v1/klines', { interval: '5m', ...payload }).then(candles =>
+  pubCall(endpoint, { interval: '5m', ...payload }).then(candles =>
     candles.map(candle => zip(candleFields, candle)),
   )
 
@@ -193,17 +198,17 @@ const order = (privCall, payload = {}, url) => {
 /**
  * Zip asks and bids reponse from order book
  */
-const book = (pubCall, payload) =>
+const book = (pubCall, payload, endpoint = '/api/v1/depth') =>
   checkParams('book', payload, ['symbol']) &&
-  pubCall('/api/v1/depth', payload).then(({ lastUpdateId, asks, bids }) => ({
+  pubCall(endpoint, payload).then(({ lastUpdateId, asks, bids }) => ({
     lastUpdateId,
     asks: asks.map(a => zip(['price', 'quantity'], a)),
     bids: bids.map(b => zip(['price', 'quantity'], b)),
   }))
 
-const aggTrades = (pubCall, payload) =>
+const aggTrades = (pubCall, payload, endpoint = '/api/v1/aggTrades') =>
   checkParams('aggTrades', payload, ['symbol']) &&
-  pubCall('/api/v1/aggTrades', payload).then(trades =>
+  pubCall(endpoint, payload).then(trades =>
     trades.map(trade => ({
       aggId: trade.a,
       price: trade.p,
@@ -218,8 +223,8 @@ const aggTrades = (pubCall, payload) =>
 
 export default opts => {
   const endpoints = {
-    'base': opts && opts.httpBase || BASE,
-    'futures': opts && opts.httpFutures || FUTURES,
+    base: (opts && opts.httpBase) || BASE,
+    futures: (opts && opts.httpFutures) || FUTURES,
   }
 
   const pubCall = publicCall({ ...opts, endpoints })
@@ -238,7 +243,8 @@ export default opts => {
     trades: payload =>
       checkParams('trades', payload, ['symbol']) && pubCall('/api/v1/trades', payload),
     tradesHistory: payload =>
-      checkParams('tradesHitory', payload, ['symbol']) && kCall('/api/v1/historicalTrades', payload),
+      checkParams('tradesHitory', payload, ['symbol']) &&
+      kCall('/api/v1/historicalTrades', payload),
 
     dailyStats: payload => pubCall('/api/v1/ticker/24hr', payload),
     prices: () =>
@@ -286,12 +292,15 @@ export default opts => {
     closeDataStream: payload => privCall('/api/v1/userDataStream', payload, 'DELETE', false, true),
 
     marginGetDataStream: () => privCall('/sapi/v1/userDataStream', null, 'POST', true),
-    marginKeepDataStream: payload => privCall('/sapi/v1/userDataStream', payload, 'PUT', false, true),
-    marginCloseDataStream: payload => privCall('/sapi/v1/userDataStream', payload, 'DELETE', false, true),
+    marginKeepDataStream: payload =>
+      privCall('/sapi/v1/userDataStream', payload, 'PUT', false, true),
+    marginCloseDataStream: payload =>
+      privCall('/sapi/v1/userDataStream', payload, 'DELETE', false, true),
 
     futuresGetDataStream: () => privCall('/fapi/v1/listenKey', null, 'POST', true),
     futuresKeepDataStream: payload => privCall('/fapi/v1/listenKey', payload, 'PUT', false, true),
-    futuresCloseDataStream: payload => privCall('/fapi/v1/listenKey', payload, 'DELETE', false, true),
+    futuresCloseDataStream: payload =>
+      privCall('/fapi/v1/listenKey', payload, 'DELETE', false, true),
 
     marginAllOrders: payload => privCall('/sapi/v1/margin/allOrders', payload),
     marginOrder: payload => order(privCall, payload, '/sapi/v1/margin/order'),
@@ -299,5 +308,32 @@ export default opts => {
     marginOpenOrders: payload => privCall('/sapi/v1/margin/openOrders', payload),
     marginAccountInfo: payload => privCall('/sapi/v1/margin/account', payload),
     marginMyTrades: payload => privCall('/sapi/v1/margin/myTrades', payload),
+
+    futuresPing: () => pubCall('/fapi/v1/ping').then(() => true),
+    futuresTime: () => pubCall('/fapi/v1/time').then(r => r.serverTime),
+    futuresExchangeInfo: () => pubCall('/fapi/v1/exchangeInfo'),
+    futuresBook: payload => book(pubCall, payload, '/fapi/v1/depth'),
+    futuresAggTrades: payload => aggTrades(pubCall, payload, '/fapi/v1/aggTrades'),
+    futuresMarkPrice: payload => pubCall('/fapi/v1/premiumIndex', payload),
+    futuresAllForceOrders: payload => pubCall('/fapi/v1/allForceOrders', payload),
+    futuresCandles: payload => candles(pubCall, payload, '/fapi/v1/klines'),
+    futuresTrades: payload =>
+      checkParams('trades', payload, ['symbol']) && pubCall('/fapi/v1/trades', payload),
+    futuresDailyStats: payload => pubCall('/fapi/v1/ticker/24hr', payload),
+    futuresPrices: () =>
+      pubCall('/fapi/v1/ticker/price').then(r =>
+        r.reduce((out, cur) => ((out[cur.symbol] = cur.price), out), {}),
+      ),
+    futuresAllBookTickers: () =>
+      pubCall('/fapi/v1/ticker/bookTicker').then(r =>
+        r.reduce((out, cur) => ((out[cur.symbol] = cur), out), {}),
+      ),
+    futuresFundingRate: payload =>
+      checkParams('fundingRate', payload, ['symbol']) && pubCall('/fapi/v1/fundingRate', payload),
+
+    futuresOrder: payload => order(privCall, payload, '/fapi/v1/order'),
+    futuresCancelOrder: payload => privCall('/fapi/v1/order', payload, 'DELETE'),
+    futuresOpenOrders: payload => privCall('/fapi/v1/openOrders', payload),
+    futuresPositionRisk: payload => privCall('/fapi/v1/positionRisk', payload),
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -84,10 +84,10 @@ test('[REST] trades', async t => {
   t.is(trades.length, 500)
 })
 
-// test('[REST] tradesHistory', async t => {
-//   const trades = await client.tradesHistory({ symbol: 'BTCUSDT' })
-//   t.is(trades.length, 500)
-// })
+test('[REST] tradesHistory', async t => {
+  const trades = await client.tradesHistory({ symbol: 'BTCUSDT' })
+  t.is(trades.length, 500)
+})
 
 test('[REST] dailyStats', async t => {
   const res = await client.dailyStats({ symbol: 'ETHBTC' })

--- a/test/index.js
+++ b/test/index.js
@@ -84,6 +84,11 @@ test('[REST] trades', async t => {
   t.is(trades.length, 500)
 })
 
+// test('[REST] tradesHistory', async t => {
+//   const trades = await client.tradesHistory({ symbol: 'BTCUSDT' })
+//   t.is(trades.length, 500)
+// })
+
 test('[REST] dailyStats', async t => {
   const res = await client.dailyStats({ symbol: 'ETHBTC' })
   t.truthy(res)
@@ -448,4 +453,124 @@ test('[WS] userEvents', t => {
   userEventHandler(res => {
     t.deepEqual(res, { type: 'totallyNewEvent', yolo: 42 })
   })({ data: JSON.stringify(newEvent) })
+})
+
+// FUTURES TESTS
+
+test('[FUTURES-REST] ping', async t => {
+  t.truthy(await client.futuresPing(), 'A simple ping should work')
+})
+
+test('[FUTURES-REST] time', async t => {
+  const ts = await client.futuresTime()
+  t.truthy(new Date(ts).getTime() > 0, 'The returned timestamp should be valid')
+})
+
+test('[FUTURES-REST] exchangeInfo', async t => {
+  const res = await client.futuresExchangeInfo()
+  checkFields(t, res, ['timezone', 'serverTime', 'rateLimits', 'symbols'])
+})
+
+test('[FUTURES-REST] book', async t => {
+  try {
+    await client.futuresBook()
+  } catch (e) {
+    t.is(e.message, 'You need to pass a payload object.')
+  }
+
+  try {
+    await client.futuresBook({})
+  } catch (e) {
+    t.is(e.message, 'Method book requires symbol parameter.')
+  }
+
+  const book = await client.futuresBook({ symbol: 'BTCUSDT' })
+  t.truthy(book.lastUpdateId)
+  t.truthy(book.asks.length)
+  t.truthy(book.bids.length)
+
+  const [bid] = book.bids
+  t.truthy(typeof bid.price === 'string')
+  t.truthy(typeof bid.quantity === 'string')
+})
+
+test('[FUTURES-REST] markPrice', async t => {
+  const res = await client.futuresMarkPrice()
+  t.truthy(Array.isArray(res))
+  checkFields(t, res[0], ['symbol', 'markPrice', 'lastFundingRate', 'nextFundingTime', 'time'])
+})
+
+test('[FUTURES-REST] allForceOrders', async t => {
+  const res = await client.futuresAllForceOrders()
+  t.truthy(Array.isArray(res))
+  t.truthy(res.length === 100)
+  checkFields(t, res[0], [
+    'symbol',
+    'price',
+    'origQty',
+    'executedQty',
+    'averagePrice',
+    'timeInForce',
+    'type',
+    'side',
+    'time',
+  ])
+})
+
+test('[FUTURES-REST] candles', async t => {
+  try {
+    await client.futuresCandles({})
+  } catch (e) {
+    t.is(e.message, 'Method candles requires symbol parameter.')
+  }
+
+  const candles = await client.candles({ symbol: 'BTCUSDT' })
+
+  t.truthy(candles.length)
+
+  const [candle] = candles
+  checkFields(t, candle, candleFields)
+})
+
+test('[FUTURES-REST] trades', async t => {
+  const trades = await client.futuresTrades({ symbol: 'BTCUSDT' })
+  t.is(trades.length, 500)
+})
+
+test('[FUTURES-REST] dailyStats', async t => {
+  const res = await client.futuresDailyStats({ symbol: 'BTCUSDT' })
+  t.truthy(res)
+  checkFields(t, res, ['highPrice', 'lowPrice', 'volume', 'priceChange'])
+})
+
+test('[FUTURES-REST] prices', async t => {
+  const prices = await client.futuresPrices()
+  t.truthy(prices)
+  t.truthy(prices.BTCUSDT)
+})
+
+test('[FUTURES-REST] allBookTickers', async t => {
+  const tickers = await client.futuresAllBookTickers()
+  t.truthy(tickers)
+  t.truthy(tickers.BTCUSDT)
+})
+
+test('[FUTURES-REST] aggTrades', async t => {
+  try {
+    await client.futuresAggTrades({})
+  } catch (e) {
+    t.is(e.message, 'Method aggTrades requires symbol parameter.')
+  }
+
+  const trades = await client.futuresAggTrades({ symbol: 'BTCUSDT' })
+  t.truthy(trades.length)
+
+  const [trade] = trades
+  t.truthy(trade.aggId)
+})
+
+test('[FUTURES-REST] fundingRate', async t => {
+  const fundingRate = await client.futuresFundingRate({ symbol: 'BTCUSDT' })
+  checkFields(t, fundingRate[0], ['symbol', 'fundingTime', 'fundingRate'])
+  t.is(fundingRate.length, 100)
 })


### PR DESCRIPTION
Add all public REST API for futures:

 *   futuresPing
 *   futuresTime
 *   futuresExchangeInfo
 *   futuresBook
 *   futuresAggTrades
 *   futuresMarkPrice
 *   futuresAllForceOrders
 *   futuresCandles
 *   futuresTrades
 *   futuresDailyStats
 *   futuresPrices
 *   futuresAllBookTickers
 *   futuresFundingRate

Add some private REST API for futures:
*    futuresOrder
*    futuresCancelOrder
*    futuresOpenOrders
*    futuresPositionRisk
 
Add tests for all public REST API method.