### PR TITLE
Added Transaction Fee to type definitions for withdrawals

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -128,6 +128,7 @@ declare module 'binance-api-node' {
         {
             id: string;
             amount: number;
+            transactionFee: number;
             address: string;
             asset: string;
             txId: string;


### PR DESCRIPTION
Per this page (https://binance-docs.github.io/apidocs/spot/en/#withdraw-history-user_data) and testing, transaction fee's are included on withdrawal responses, but not in the typescript definition below. Fixed to include.