### PR TITLE
feat(oco): support new OCO orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Following examples will use the `await` form, which requires some configuration 
 - [Authenticated REST Endpoints](#authenticated-rest-endpoints)
   - [order](#order)
   - [orderTest](#ordertest)
+  - [orderOco](#orderoco)
   - [getOrder](#getorder)
   - [cancelOrder](#cancelorder)
   - [openOrders](#openorders)
@@ -920,6 +921,110 @@ Additional mandatory parameters based on `type`:
 Test new order creation and signature/recvWindow. Creates and validates a new order but does not send it into the matching engine.
 
 Same API as above, but does not return any output on success.
+
+#### orderOco
+
+Creates a new OCO order.
+
+```js
+console.log(
+  await client.orderOco({
+    symbol: 'XLMETH',
+    side: 'SELL',
+    quantity: 100,
+    price: 0.0002,
+    stopPrice: 0.0001,
+    stopLimitPrice: 0.0001,
+  }),
+)
+```
+
+| Param                | Type   | Required | Description
+|----------------------|--------|----------|------------
+| symbol               | String | true     |
+| listClientOrderId    | String | false    | A unique Id for the entire orderList
+| side                 | String | true     | `BUY`,`SELL`
+| quantity             | Number | true     |
+| limitClientOrderId   | String | false    | A unique Id for the limit order
+| price                | Number | true     |
+| limitIcebergQty      | Number | false    | Used to make the `LIMIT_MAKER` leg an iceberg order.
+| stopClientOrderId    | String | false    | A unique Id for the stop loss/stop loss limit leg
+| stopPrice            | Number | true
+| stopLimitPrice       | Number | false    | If provided, `stopLimitTimeInForce` is required.
+| stopIcebergQty       | Number | false    | Used with `STOP_LOSS_LIMIT` leg to make an iceberg order.
+| stopLimitTimeInForce | String | false    | `FOK`, `GTC`, `IOC`
+| newOrderRespType     | String | false    | Returns more complete info of the order. `ACK`, `RESULT`, or `FULL`
+| recvWindow           | Number | false    | The value cannot be greater than `60000`
+
+Additional Info:
+- Price Restrictions:
+    - `SELL`: Limit Price > Last Price > Stop Price
+    - `BUY`: Limit Price < Last Price < Stop Price
+- Quantity Restrictions:
+    - Both legs must have the same quantity.
+    - ```ICEBERG``` quantities however do not have to be the same
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  "orderListId": 0,
+  "contingencyType": "OCO",
+  "listStatusType": "EXEC_STARTED",
+  "listOrderStatus": "EXECUTING",
+  "listClientOrderId": "JYVpp3F0f5CAG15DhtrqLp",
+  "transactionTime": 1514418413947,
+  "symbol": "XLMETH",
+  "orders": [
+    {
+      "symbol": "XLMETH",
+      "orderId": 1740797,
+      "clientOrderId": "1XZTVBTGS4K1e"
+    },
+    {
+      "symbol": "XLMETH",
+      "orderId": 1740798,
+      "clientOrderId": "1XZTVBTGS4K1f"
+    }
+  ],
+  "orderReports": [
+    {
+      "symbol": "XLMETH",
+      "orderId": 1740797,
+      "orderListId": 0,
+      "clientOrderId": "1XZTVBTGS4K1e",
+      "transactTime": 1514418413947,
+      "price": "0.000000",
+      "origQty": "100",
+      "executedQty": "0.000000",
+      "cummulativeQuoteQty": "0.000000",
+      "status": "NEW",
+      "timeInForce": "GTC",
+      "type": "STOP_LOSS",
+      "side": "SELL",
+      "stopPrice": "0.0001"
+    },
+    {
+      "symbol": "XLMETH",
+      "orderId": 1740798,
+      "orderListId": 0,
+      "clientOrderId": "1XZTVBTGS4K1f",
+      "transactTime": 1514418413947,
+      "price": "0.0002",
+      "origQty": "100",
+      "executedQty": "0.000000",
+      "cummulativeQuoteQty": "0.000000",
+      "status": "NEW",
+      "timeInForce": "GTC",
+      "type": "LIMIT_MAKER",
+      "side": "SELL"
+    }
+  ]
+}
+```
+
+</details>
 
 #### getOrder
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -160,6 +160,7 @@ declare module 'binance-api-node' {
         exchangeInfo(): Promise<ExchangeInfo>;
         order(options: NewOrder): Promise<Order>;
         orderTest(options: NewOrder): Promise<Order>;
+        orderOco(options: NewOcoOrder): Promise<OcoOrder>;
         ping(): Promise<boolean>;
         prices(): Promise<{ [index: string]: string }>;
         avgPrice(options?: { symbol: string }): Promise<AvgPriceResult | AvgPriceResult[]>;
@@ -344,6 +345,24 @@ declare module 'binance-api-node' {
         newOrderRespType?: NewOrderRespType;
     }
 
+    export interface NewOcoOrder {
+        symbol: string;
+        listClientOrderId?: string;
+        side: OrderSide;
+        quantity: string;
+        limitClientOrderId?: string;
+        price: string;
+        limitIcebergQty?: string;
+        stopClientOrderId?: string;
+        stopPrice: string;
+        stopLimitPrice?: string;
+        stopIcebergQty?: string;
+        stopLimitTimeInForce?: TimeInForce;
+        newOrderRespType?: NewOrderRespType;
+        recvWindow?: number;
+        useServerTime?: boolean;
+    }
+
     interface OrderFill {
         price: string;
         qty: string;
@@ -353,9 +372,11 @@ declare module 'binance-api-node' {
 
     interface Order {
         clientOrderId: string;
+        cummulativeQuoteQty: string,
         executedQty: string;
         icebergQty?: string;
         orderId: number;
+        orderListId: number;
         origQty: string;
         price: string;
         side: OrderSide;
@@ -366,6 +387,18 @@ declare module 'binance-api-node' {
         transactTime: number;
         type: OrderType;
         fills?: OrderFill[];
+    }
+
+    interface OcoOrder {
+        orderListId: number;
+        contingencyType: ContingencyType;
+        listStatusType: ListStatusType;
+        listOrderStatus: ListOrderStatus;
+        listClientOrderId: string;
+        transactionTime: number;
+        symbol: string;
+        orders: Order[];
+        orderReports: Order[];
     }
 
     export type OrderSide = 'BUY' | 'SELL';
@@ -387,6 +420,18 @@ declare module 'binance-api-node' {
         | 'STOP_LOSS_LIMIT'
         | 'TAKE_PROFIT'
         | 'TAKE_PROFIT_LIMIT';
+
+    export type ListOrderStatus =
+        | 'EXECUTING'
+        | 'ALL_DONE'
+        | 'REJECT';
+
+    export type ListStatusType =
+        | 'RESPONSE'
+        | 'EXEC_STARTED'
+        | 'ALL_DONE';
+
+    export type ContingencyType = 'OCO';
 
     export type NewOrderRespType = 'ACK' | 'RESULT' | 'FULL';
 

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -196,6 +196,18 @@ const order = (privCall, payload = {}, url) => {
   )
 }
 
+const orderOco = (privCall, payload = {}, url) => {
+  const newPayload =
+    payload.stopLimitPrice && !payload.stopLimitTimeInForce
+      ? { stopLimitTimeInForce: 'GTC', ...payload }
+      : payload
+
+  return (
+    checkParams('order', newPayload, ['symbol', 'side', 'quantity', 'price', 'stopPrice']) &&
+    privCall(url, newPayload, 'POST')
+  )
+}
+
 /**
  * Zip asks and bids reponse from order book
  */
@@ -271,6 +283,7 @@ export default opts => {
     publicRequest: (method, url, payload) => pubCall(url, payload, method),
 
     order: payload => order(privCall, payload, '/api/v3/order'),
+    orderOco: payload => orderOco(privCall, payload, '/api/v3/order/oco'),
     orderTest: payload => order(privCall, payload, '/api/v3/order/test'),
     getOrder: payload => privCall('/api/v3/order', payload),
     cancelOrder: payload => privCall('/api/v3/order', payload, 'DELETE'),


### PR DESCRIPTION
Add support for "New OCO" order endpoint.

See: https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#new-oco-trade