### PR TITLE
feat(websocket): Map balance update user event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -556,11 +556,6 @@ declare module 'binance-api-node' {
         tradeId: number;
     }
 
-    export interface Message {
-        eventType: EventType;
-        eventTime: number;
-    }
-
     export interface Balances {
         [key: string]: {
             available: string;
@@ -568,7 +563,7 @@ declare module 'binance-api-node' {
         };
     }
 
-    export interface OutboundAccountInfo extends Message {
+    export interface OutboundAccountInfo {
         balances: Balances;
         makerCommissionRate: number;
         takerCommissionRate: number;
@@ -578,9 +573,11 @@ declare module 'binance-api-node' {
         canWithdraw: boolean;
         canDeposit: boolean;
         lastAccountUpdate: number;
+        eventType: 'account';
+        eventTime: number;
     }
 
-    export interface ExecutionReport extends Message {
+    export interface ExecutionReport {
         symbol: string;
         newClientOrderId: string;
         originalClientOrderId: string;
@@ -605,6 +602,8 @@ declare module 'binance-api-node' {
         isOrderWorking: boolean;
         isBuyerMaker: boolean;
         totalQuoteTradeQuantity: string;
+        eventType: 'executionReport';
+        eventTime: number;
     }
 
     export interface TradeResult {

--- a/index.d.ts
+++ b/index.d.ts
@@ -460,6 +460,20 @@ declare module 'binance-api-node' {
 
     export type TimeInForce = 'GTC' | 'IOC' | 'FOK';
 
+    export enum OrderRejectReason {
+        ACCOUNT_CANNOT_SETTLE = 'ACCOUNT_CANNOT_SETTLE',
+        ACCOUNT_INACTIVE = 'ACCOUNT_INACTIVE',
+        DUPLICATE_ORDER = 'DUPLICATE_ORDER',
+        INSUFFICIENT_BALANCE = 'INSUFFICIENT_BALANCE',
+        MARKET_CLOSED = 'MARKET_CLOSED',
+        NONE = 'NONE',
+        ORDER_WOULD_TRIGGER_IMMEDIATELY = 'ORDER_WOULD_TRIGGER_IMMEDIATELY',
+        PRICE_QTY_EXCEED_HARD_LIMITS = 'PRICE_QTY_EXCEED_HARD_LIMITS',
+        UNKNOWN_ACCOUNT = 'UNKNOWN_ACCOUNT',
+        UNKNOWN_INSTRUMENT = 'UNKNOWN_INSTRUMENT',
+        UNKNOWN_ORDER = 'UNKNOWN_ORDER'
+    }
+
     export type ExecutionType =
         | 'NEW'
         | 'CANCELED'
@@ -467,10 +481,6 @@ declare module 'binance-api-node' {
         | 'REJECTED'
         | 'TRADE'
         | 'EXPIRED';
-
-    export type EventType =
-        | 'executionReport'
-        | 'account';
 
     export interface Depth {
         eventType: string;
@@ -599,7 +609,7 @@ declare module 'binance-api-node' {
         stopPrice: string;
         icebergQuantity: string;
         orderStatus: OrderStatus;
-        orderRejectReason: string;
+        orderRejectReason: OrderRejectReason;
         orderId: number;
         orderTime: number;
         lastTradeQuantity: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -207,6 +207,8 @@ declare module 'binance-api-node' {
         url: string;
     }
 
+    export type UserDataStreamEvent = OutboundAccountInfo | ExecutionReport | BalanceUpdate;
+
     export interface WebSocket {
         depth: (pair: string | string[], callback: (depth: Depth) => void) => ReconnectingWebSocketHandler;
         partialDepth: (options: { symbol: string, level: number } | { symbol: string, level: number }[], callback: (depth: PartialDepth) => void) => ReconnectingWebSocketHandler;
@@ -215,8 +217,7 @@ declare module 'binance-api-node' {
         candles: (pair: string | string[], period: string, callback: (ticker: Candle) => void) => ReconnectingWebSocketHandler;
         trades: (pairs: string | string[], callback: (trade: Trade) => void) => ReconnectingWebSocketHandler;
         aggTrades: (pairs: string | string[], callback: (trade: Trade) => void) => ReconnectingWebSocketHandler;
-
-        user: (callback: (msg: OutboundAccountInfo | ExecutionReport) => void) => Function;
+        user: (callback: (msg: UserDataStreamEvent) => void) => Function;
         marginUser: (callback: (msg: OutboundAccountInfo | ExecutionReport) => void) => Function;
         futuresUser: (callback: (msg: OutboundAccountInfo | ExecutionReport) => void) => Function;
     }
@@ -575,6 +576,14 @@ declare module 'binance-api-node' {
         lastAccountUpdate: number;
         eventType: 'account';
         eventTime: number;
+    }
+
+    export interface BalanceUpdate {
+        asset: string;
+        balanceDelta: number;
+        clearTime: number;
+        eventTime: number;
+        eventType: 'balanceUpdate';
     }
 
     export interface ExecutionReport {

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -252,6 +252,15 @@ const aggTrades = (payload, cb) => aggTradesInternal(payload, cb)
 const trades = (payload, cb) => tradesInternal(payload, cb)
 
 const userTransforms = {
+  // https://github.com/binance-exchange/binance-official-api-docs/blob/master/user-data-stream.md#balance-update
+  balanceUpdate: m => ({
+    asset: m.a,
+    balanceDelta: m.d,
+    clearTime: m.T,
+    eventTime: m.E,
+    eventType: 'balanceUpdate',
+  }),
+  // https://github.com/binance-exchange/binance-official-api-docs/blob/master/user-data-stream.md#account-update
   outboundAccountInfo: m => ({
     eventType: 'account',
     eventTime: m.E,
@@ -268,6 +277,7 @@ const userTransforms = {
       return out
     }, {}),
   }),
+  // https://github.com/binance-exchange/binance-official-api-docs/blob/master/user-data-stream.md#order-update
   executionReport: m => ({
     eventType: 'executionReport',
     eventTime: m.E,


### PR DESCRIPTION
As suggested [here](https://github.com/Ashlar/binance-api-node/pull/259#issuecomment-636569187)  I am remapping the `balanceUpdate` user event from the Binance API WebSocket.

On top of that I am specifying all `OrderRejectReason` types and I dissolved the `Message interface` because it was preventing TypeScript's [tagged union type functionality](https://mariusschulz.com/blog/tagged-union-types-in-typescript).

I also added linked the Binance API in the remapping code because it helped me to understand what's going on there. I think it is very useful for external contributors.