### PR TITLE
Add the methods for querying capital/deposit information

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Following examples will use the `await` form, which requires some configuration 
   - [withdraw](#withdraw)
   - [depositAddress](#depositaddress)
   - [tradeFee](#tradefee)
+  - [capitalConfigs](#capitalConfigs)
+  - [capitalDepositAddress](#capitalDepositAddress)
 - [Websockets](#websockets)
   - [depth](#depth)
   - [partialDepth](#partialdepth)
@@ -1552,6 +1554,88 @@ console.log(await client.tradeFee())
   success: true,
 }
 
+```
+
+</details>
+
+#### capitalConfigs
+
+Get information of coins (available for deposit and withdraw) for user.
+
+```js
+console.log(await client.capitalConfigs())
+```
+
+<details>
+<summary>Output</summary>
+
+```js
+[
+  {
+    'coin': 'CTR',
+    'depositAllEnable': false,
+    'free': '0.00000000',
+    'freeze': '0.00000000',
+    'ipoable': '0.00000000',
+    'ipoing': '0.00000000',
+    'isLegalMoney': false,
+    'locked': '0.00000000',
+    'name': 'Centra',
+    'networkList': [
+      {
+        'addressRegex': '^(0x)[0-9A-Fa-f]{40}$',
+        'coin': 'CTR',
+        'depositDesc': 'Delisted, Deposit Suspended',
+        'depositEnable': false,
+        'isDefault': true,
+        'memoRegex': '',
+        'minConfirm': 12,
+        'name': 'ERC20',
+        'network': 'ETH',
+        'resetAddressStatus': false,
+        'specialTips': '',
+        'unLockConfirm': 0,
+        'withdrawDesc': '',
+        'withdrawEnable': true,
+        'withdrawFee': '35.00000000',
+        'withdrawIntegerMultiple': '0.00000001',
+        'withdrawMax': '0.00000000',
+        'withdrawMin': '70.00000000'
+      }
+    ],
+    'storage': '0.00000000',
+    'trading': false,
+    'withdrawAllEnable': true,
+    'withdrawing': '0.00000000'
+  }
+]
+```
+
+</details>
+
+#### capitalDepositAddress
+
+Fetch deposit address with network.
+
+```js
+console.log(await client.capitalDepositAddress({ coin: 'NEO' }))
+```
+
+| Param    | Type   | Required | Description      |
+| -------- | ------ | -------- | ---------------- |
+| coin     | String | true     | The coin name    |
+| network  | String | false    | The network name |
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  address: 'AM6ytPW78KYxQCmU2pHYGcee7GypZ7Yhhc',
+  coin: 'NEO',
+  tag: '',
+  url: 'https://neoscan.io/address/AM6ytPW78KYxQCmU2pHYGcee7GypZ7Yhhc'
+}
 ```
 
 </details>

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -305,6 +305,9 @@ export default opts => {
     tradeFee: payload => privCall('/wapi/v3/tradeFee.html', payload),
     assetDetail: payload => privCall('/wapi/v3/assetDetail.html', payload),
 
+    capitalConfigs: () => privCall('/sapi/v1/capital/config/getall'),
+    capitalDepositAddress: payload => privCall('/sapi/v1/capital/deposit/address', payload),
+
     getDataStream: () => privCall('/api/v3/userDataStream', null, 'POST', true),
     keepDataStream: payload => privCall('/api/v3/userDataStream', payload, 'PUT', false, true),
     closeDataStream: payload => privCall('/api/v3/userDataStream', payload, 'DELETE', false, true),


### PR DESCRIPTION
This PR adds the following methods for querying capital/deposit information with network names.

- capitalConfigs ([docs](https://binance-docs.github.io/apidocs/spot/en/#all-coins-39-information-user_data))
- capitalDepositAddress ([docs](https://binance-docs.github.io/apidocs/spot/en/#deposit-address-supporting-network-user_data))