### PR TITLE
Add payload for /ticker/price endpoint

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -173,7 +173,9 @@ declare module 'binance-api-node' {
     orderTest(options: NewOrder): Promise<Order>
     orderOco(options: NewOcoOrder): Promise<OcoOrder>
     ping(): Promise<boolean>
-    prices(): Promise<{ [index: string]: string }>
+    prices(options?: {
+      symbol?: string
+    }): Promise<{ [index: string]: string }>
     avgPrice(options?: { symbol: string }): Promise<AvgPriceResult | AvgPriceResult[]>
     time(): Promise<number>
     trades(options: { symbol: string; limit?: number }): Promise<TradeResult[]>

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -261,7 +261,7 @@ export default opts => {
       kCall('/api/v3/historicalTrades', payload),
 
     dailyStats: payload => pubCall('/api/v3/ticker/24hr', payload),
-    prices: () =>
+    prices: payload =>
       pubCall('/api/v3/ticker/price').then(r =>
         r.reduce((out, cur) => ((out[cur.symbol] = cur.price), out), {}),
       ),

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -262,7 +262,7 @@ export default opts => {
 
     dailyStats: payload => pubCall('/api/v3/ticker/24hr', payload),
     prices: payload =>
-      pubCall('/api/v3/ticker/price').then(r =>
+      pubCall('/api/v3/ticker/price', payload).then(r =>
         r.reduce((out, cur) => ((out[cur.symbol] = cur.price), out), {}),
       ),
 


### PR DESCRIPTION
I add the missing payload to reduce requests cost if the price for only one symbol needed.