### PR TITLE
Pass option for websocket endpoint

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,8 @@ declare module 'binance-api-node' {
     apiKey: string
     apiSecret: string
     getTime?: () => number | Promise<number>
+    httpBase?: string
+    wsBase?: string
   }): Binance
 
   export enum ErrorCodes {


### PR DESCRIPTION
This PR adds options in the Binance constructor to pass a parameter `wsBase` which, like the `httpBase` param for the REST API, sets the websocket endpoint.

The goal here is to allow the library to be used with Binance.us