### PR TITLE
feat(websocket): Type close handles for user event streams

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -310,16 +310,18 @@ declare module 'binance-api-node' {
       pairs: string | string[],
       callback: (trade: Trade) => void,
     ) => ReconnectingWebSocketHandler
-    user: (callback: (msg: UserDataStreamEvent) => void) => Function
-    marginUser: (callback: (msg: OutboundAccountInfo | ExecutionReport) => void) => Function
-    futuresUser: (callback: (msg: OutboundAccountInfo | ExecutionReport) => void) => Function
+    user: (callback: (msg: UserDataStreamEvent) => void) => Promise<ReconnectingWebSocketHandler>
+    marginUser: (callback: (msg: OutboundAccountInfo | ExecutionReport) => void) => Promise<ReconnectingWebSocketHandler>
+    futuresUser: (callback: (msg: OutboundAccountInfo | ExecutionReport) => void) => Promise<ReconnectingWebSocketHandler>
   }
 
-  export type ReconnectingWebSocketHandler = (options?: {
-    keepClosed: boolean
-    fastClose: boolean
-    delay: number
-  }) => void
+  export type WebSocketCloseOptions = {
+    delay: number;
+    fastClose: boolean;
+    keepClosed: boolean;
+  }
+
+  export type ReconnectingWebSocketHandler = (options?: WebSocketCloseOptions) => void
 
   export enum CandleChartInterval {
     ONE_MINUTE = '1m',


### PR DESCRIPTION
I logged the return type (`clean`) of the user WebSocket subscription and it turned out it is a Promise which includes a close handler.

**How I tested  it:**

```js
const clean = client.ws.user(() => {});
console.log('handle type', clean); // "Promise { <pending> }"
```

**Usage:**

```js
const clean = await exchange.client.ws.user(() => {});
console.log('handle execution', await clean({keepClosed: false}));
```