### PR TITLE
Fix type for balance delta

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -670,7 +670,7 @@ declare module 'binance-api-node' {
 
   export interface BalanceUpdate {
     asset: string
-    balanceDelta: number
+    balanceDelta: string
     clearTime: number
     eventTime: number
     eventType: 'balanceUpdate'


### PR DESCRIPTION
I logged the user event for a `balanceUpdate` and it's `balanceDelta` is a string.

**Example payload**

```ts
{
  asset: 'BNB',
  balanceDelta: '0.00134811',
  clearTime: 1605776348183,
  eventTime: 1605776348185,
  eventType: 'balanceUpdate'
}
```