### PR TITLE
feat: Added quoteOrderQty at Order

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -190,10 +190,10 @@ const order = (privCall, payload = {}, url) => {
       ? { timeInForce: 'GTC', ...payload }
       : payload
 
-  const requires = ['symbol', 'side'];
+  const requires = ['symbol', 'side']
 
   if (!(newPayload.type === 'MARKET' && newPayload.quoteOrderQty)) {
-    requires.push('quantity');
+    requires.push('quantity')
   }
 
   return (

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -190,8 +190,14 @@ const order = (privCall, payload = {}, url) => {
       ? { timeInForce: 'GTC', ...payload }
       : payload
 
+  const requires = ['symbol', 'side'];
+
+  if (!(newPayload.type === 'MARKET' && newPayload.quoteOrderQty)) {
+    requires.push('quantity');
+  }
+
   return (
-    checkParams('order', newPayload, ['symbol', 'side', 'quantity']) &&
+    checkParams('order', newPayload, requires) &&
     privCall(url, { type: 'LIMIT', ...newPayload }, 'POST')
   )
 }

--- a/test/auth.js
+++ b/test/auth.js
@@ -42,6 +42,29 @@ const main = () => {
     t.pass()
   })
 
+  test('[REST] make a MARKET order with quoteOrderQty', async t => {
+    try {
+      await client.orderTest({
+        symbol: 'ETHBTC',
+        side: 'BUY',
+        quoteOrderQty: 10,
+        type: 'MARKET'
+      })
+    } catch (e) {
+      t.is(e.message, 'Filter failure: PERCENT_PRICE')
+    }
+
+    await client.orderTest({
+      symbol: 'ETHBTC',
+      side: 'BUY',
+      quantity: 1,
+      type: 'MARKET',
+    })
+
+    t.pass()
+  })
+
+
   test('[REST] allOrders / getOrder', async t => {
     try {
       await client.getOrder({ symbol: 'ASTETH' })


### PR DESCRIPTION
When you send a `type=MARKET ` order, you can send quoteOrderQty instead of quantity.

I added this feat in the order method.
Also added a new test to check that it works well.

More info: https://binance-docs.github.io/apidocs/spot/en/#new-order-trade
(or searching for quoteOrderQty)