### PR TITLE
feat: Added margin repay endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Following examples will use the `await` form, which requires some configuration 
   - [tradeFee](#tradefee)
   - [capitalConfigs](#capitalConfigs)
   - [capitalDepositAddress](#capitalDepositAddress)
+- [Margin](#margin)
+  - [marginRepay](#marginRepay)
 - [Futures Authenticated REST Endpoints](#futures-authenticated-rest-endpoints)
   - [futuresAccountBalance](#futuresAccountBalance)
 - [Websockets](#websockets)
@@ -1645,6 +1647,34 @@ console.log(await client.capitalDepositAddress({ coin: 'NEO' }))
 ```
 
 </details>
+
+### Margin
+
+#### marginRepay
+
+Repay loan for margin account.
+
+```js
+console.log(await client.marginRepay({ asset: 'BTC', amount:'0.0001' }));
+```
+
+| Param | Type   | Required | Description    |
+| ----- | ------ | -------- | -------------- |
+| asset | String | true     | The asset name |
+| amount | Number | true     | 
+
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+    "tranId": 100000001 //transaction id
+}
+```
+
+</details>
+
 
 ### Futures Authenticated REST endpoints
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -290,9 +290,6 @@ declare module 'binance-api-node' {
     marginRepay(options: { asset: string; amount:number; useServerTime?: boolean }): Promise<{tranId:number}>
   }
 
-
-
-
   export interface HttpError extends Error {
     code: number
     url: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -287,7 +287,11 @@ declare module 'binance-api-node' {
       useServerTime?: boolean
     }): Promise<CancelOrderResult>
     marginOpenOrders(options: { symbol?: string; useServerTime?: boolean }): Promise<QueryOrderResult[]>
+    marginRepay(options: { asset: string; amount:number; useServerTime?: boolean }): Promise<{tranId:number}>
   }
+
+
+
 
   export interface HttpError extends Error {
     code: number

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -335,6 +335,7 @@ export default opts => {
     marginOpenOrders: payload => privCall('/sapi/v1/margin/openOrders', payload),
     marginAccountInfo: payload => privCall('/sapi/v1/margin/account', payload),
     marginMyTrades: payload => privCall('/sapi/v1/margin/myTrades', payload),
+    marginRepay: payload => privCall('/sapi/v1/margin/repay', payload, 'POST'),
 
     futuresPing: () => pubCall('/fapi/v1/ping').then(() => true),
     futuresTime: () => pubCall('/fapi/v1/time').then(r => r.serverTime),


### PR DESCRIPTION
Added a new endpoint for repaying at margin trading.

Added also the interface.

I didn't attach test because you only be able to test it if you have assets with borrow or interests to repay.