### PR TITLE
Add trading type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,12 +50,14 @@ declare module 'binance-api-node' {
   }
 
   export interface Account {
+    accountType: TradingType.MARGIN | TradingType.SPOT
     balances: AssetBalance[]
     buyerCommission: number
     canDeposit: boolean
     canTrade: boolean
     canWithdraw: boolean
     makerCommission: number
+    permissions: TradingType[]
     sellerCommission: number
     takerCommission: number
     updateTime: number
@@ -355,6 +357,11 @@ declare module 'binance-api-node' {
   }
 
   export type RateLimitType = 'REQUEST_WEIGHT' | 'ORDERS'
+
+  export enum TradingType {
+    MARGIN = 'MARGIN',
+    SPOT = 'SPOT',
+  }
 
   export type RateLimitInterval = 'SECOND' | 'MINUTE' | 'DAY'
 


### PR DESCRIPTION
Binance added a trading type and permissions to the Account Info: https://binance-docs.github.io/apidocs/spot/en/#account-information-user_data