### PR TITLE
Add URL configuration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,8 @@ declare module 'binance-api-node' {
     getTime?: () => number | Promise<number>
     httpBase?: string
     httpFutures?: string
+    wsBase?: string
+    wsFutures?: string
   }): Binance
 
   export enum ErrorCodes {

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,8 @@ declare module 'binance-api-node' {
     apiKey: string
     apiSecret: string
     getTime?: () => number | Promise<number>
+    httpBase?: string
+    httpFutures?: string
   }): Binance
 
   export enum ErrorCodes {


### PR DESCRIPTION
I discovered that you can set `httpBase` and `httpFutures` URLs on the Binance client, which is pretty cool when you want to use it with a proxy server in between. 🙂