### PR TITLE
Make API Key and API Secret optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 // tslint:disable:interface-name
 declare module 'binance-api-node' {
   export default function(options?: {
-    apiKey: string
-    apiSecret: string
+    apiKey?: string
+    apiSecret?: string
     getTime?: () => number | Promise<number>
     httpBase?: string
     httpFutures?: string


### PR DESCRIPTION
It's possible to create a Binance Public client:
```
const client = Binance()
```
By making the API Key and API Secret optional (which they are), we can support creating public clients which use proxy routes:
```
const client = Binance({httpBase: '/api-binance'})
```