### PR TITLE
add support for futures liquidation streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -2633,6 +2633,68 @@ client.ws.aggTrades(['ETHBTC', 'BNBBTC'], trade => {
 
 </details>
 
+#### futuresLiquidations
+
+Live liquidation data feed. Pass either a single symbol string or an array of symbols. The Liquidation Order Streams push force liquidation order information for specific symbol(s).
+
+```js
+client.ws.futuresLiquidations(['ETHBTC', 'BNBBTC'], liquidation => {
+  console.log(liquidation)
+})
+```
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  symbol: string
+  price: '0.04923600',
+  origQty: '3.43500000',
+  lastFilledQty: '3.43500000',
+  accumulatedQty: '3.43500000',
+  averagePrice: '0.04923600',
+  status: 'FILLED',
+  timeInForce: 'IOC',
+  type: 'LIMIT',
+  side: 'SELL',
+  time: 1508614495050
+}
+```
+
+</details>
+
+#### allFuturesLiquidations
+
+Live liquidation data feed. Pass either a single symbol string or an array of symbols. The All Liquidation Order Streams push force liquidation order information for all symbols in the market.
+
+```js
+client.ws.allFuturesLiquidations(liquidation => {
+  console.log(liquidation)
+})
+```
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  symbol: string
+  price: '0.04923600',
+  origQty: '3.43500000',
+  lastFilledQty: '3.43500000',
+  accumulatedQty: '3.43500000',
+  averagePrice: '0.04923600',
+  status: 'FILLED',
+  timeInForce: 'IOC',
+  type: 'LIMIT',
+  side: 'SELL',
+  time: 1508614495050
+}
+```
+
+</details>
+
 #### user
 
 Live user messages data feed.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Following examples will use the `await` form, which requires some configuration 
   - [futuresAllTickers](#futuresAlltickers)
   - [futuresCandles](#futuresCandles)
   - [futuresAggTrades](#futuresAggtrades)
+  - [futuresLiquidations](#futuresLiquidations)
+  - [futuresAllLiquidations](#futuresAllLiquidations)
   - [futuresUser](#futuresUser)
 - [Common](#common)
   - [getInfo](#getInfo)
@@ -2633,68 +2635,6 @@ client.ws.aggTrades(['ETHBTC', 'BNBBTC'], trade => {
 
 </details>
 
-#### futuresLiquidations
-
-Live liquidation data feed. Pass either a single symbol string or an array of symbols. The Liquidation Order Streams push force liquidation order information for specific symbol(s).
-
-```js
-client.ws.futuresLiquidations(['ETHBTC', 'BNBBTC'], liquidation => {
-  console.log(liquidation)
-})
-```
-
-<details>
-<summary>Output</summary>
-
-```js
-{
-  symbol: string
-  price: '0.04923600',
-  origQty: '3.43500000',
-  lastFilledQty: '3.43500000',
-  accumulatedQty: '3.43500000',
-  averagePrice: '0.04923600',
-  status: 'FILLED',
-  timeInForce: 'IOC',
-  type: 'LIMIT',
-  side: 'SELL',
-  time: 1508614495050
-}
-```
-
-</details>
-
-#### allFuturesLiquidations
-
-Live liquidation data feed. Pass either a single symbol string or an array of symbols. The All Liquidation Order Streams push force liquidation order information for all symbols in the market.
-
-```js
-client.ws.allFuturesLiquidations(liquidation => {
-  console.log(liquidation)
-})
-```
-
-<details>
-<summary>Output</summary>
-
-```js
-{
-  symbol: string
-  price: '0.04923600',
-  origQty: '3.43500000',
-  lastFilledQty: '3.43500000',
-  accumulatedQty: '3.43500000',
-  averagePrice: '0.04923600',
-  status: 'FILLED',
-  timeInForce: 'IOC',
-  type: 'LIMIT',
-  side: 'SELL',
-  time: 1508614495050
-}
-```
-
-</details>
-
 #### user
 
 Live user messages data feed.
@@ -2958,6 +2898,69 @@ client.ws.futuresAggTrades(['ETHBTC', 'BNBBTC'], trade => {
   isBuyerMaker: false,
 }
 ```
+</details>
+
+
+#### futuresLiquidations
+
+Live liquidation data feed. Pass either a single symbol string or an array of symbols. The Liquidation Order Streams push force liquidation order information for specific symbol(s).
+
+```js
+client.ws.futuresLiquidations(['ETHBTC', 'BNBBTC'], liquidation => {
+  console.log(liquidation)
+})
+```
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  symbol: string
+  price: '0.04923600',
+  origQty: '3.43500000',
+  lastFilledQty: '3.43500000',
+  accumulatedQty: '3.43500000',
+  averagePrice: '0.04923600',
+  status: 'FILLED',
+  timeInForce: 'IOC',
+  type: 'LIMIT',
+  side: 'SELL',
+  time: 1508614495050
+}
+```
+
+</details>
+
+#### futuresAllLiquidations
+
+Live liquidation data feed. Pass either a single symbol string or an array of symbols. The All Liquidation Order Streams push force liquidation order information for all symbols in the market.
+
+```js
+client.ws.futuresAllLiquidations(liquidation => {
+  console.log(liquidation)
+})
+```
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  symbol: string
+  price: '0.04923600',
+  origQty: '3.43500000',
+  lastFilledQty: '3.43500000',
+  accumulatedQty: '3.43500000',
+  averagePrice: '0.04923600',
+  status: 'FILLED',
+  timeInForce: 'IOC',
+  type: 'LIMIT',
+  side: 'SELL',
+  time: 1508614495050
+}
+```
+
 </details>
 
 #### futuresUser

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 // tslint:disable:interface-name
 declare module 'binance-api-node' {
-  export default function(options?: {
+  export default function (options?: {
     apiKey?: string
     apiSecret?: string
     getTime?: () => number | Promise<number>
@@ -160,7 +160,7 @@ declare module 'binance-api-node' {
     }
   }
 
-  export type GetOrderOptions = {symbol: string, orderId: number} | {symbol: string, origClientOrderId: string}
+  export type GetOrderOptions = { symbol: string, orderId: number } | { symbol: string, origClientOrderId: string }
 
   export interface GetInfo {
     spot: GetInfoDetails
@@ -175,7 +175,7 @@ declare module 'binance-api-node' {
     orderCount1d?: string
     responseTime?: string
   }
-  
+
   export type TransferType = 'MAIN_C2C' |
     'MAIN_UMFUTURE' |
     'MAIN_CMFUTURE' |
@@ -221,7 +221,7 @@ declare module 'binance-api-node' {
       timestamp: number
     }[]
   }
-  
+
   export interface Binance {
     getInfo(): GetInfo
     accountInfo(options?: { useServerTime: boolean }): Promise<Account>
@@ -253,7 +253,7 @@ declare module 'binance-api-node' {
       fromId?: number
       useServerTime?: boolean
     }): Promise<MyTrade[]>
-    getOrder(options: GetOrderOptions & {useServerTime?: boolean}): Promise<QueryOrderResult>
+    getOrder(options: GetOrderOptions & { useServerTime?: boolean }): Promise<QueryOrderResult>
     cancelOrder(options: {
       symbol: string
       orderId: number
@@ -300,7 +300,7 @@ declare module 'binance-api-node' {
       startTime?: number
       endTime?: number
     }): Promise<DepositHistoryResponse>
-    universalTransfer(options: UniversalTransfer): Promise<{tranId: number}>
+    universalTransfer(options: UniversalTransfer): Promise<{ tranId: number }>
     universalTransferHistory(options: UniversalTransferHistory): Promise<UniversalTransferHistoryResponse>
     futuresPing(): Promise<boolean>
     futuresTime(): Promise<number>
@@ -356,13 +356,13 @@ declare module 'binance-api-node' {
       useServerTime?: boolean
     }): Promise<CancelOrderResult>
     marginOpenOrders(options: { symbol?: string; useServerTime?: boolean }): Promise<QueryOrderResult[]>
-    marginRepay(options: { asset: string; amount:number; useServerTime?: boolean }): Promise<{tranId:number}>
-    marginLoan(options: { asset: string; amount:number; useServerTime?: boolean }): Promise<{tranId:number}>
+    marginRepay(options: { asset: string; amount: number; useServerTime?: boolean }): Promise<{ tranId: number }>
+    marginLoan(options: { asset: string; amount: number; useServerTime?: boolean }): Promise<{ tranId: number }>
     marginIsolatedAccount(options?: { symbols?: string; recvWindow?: number }): Promise<IsolatedMarginAccount>
-    marginMaxBorrow(options: {asset: string, isolatedSymbol?: string, recvWindow?: number}): Promise<{amount: string, borrowLimit: string}>
-    marginCreateIsolated(options: {base: string, quote: string, recvWindow?: number}): Promise<{success: boolean, symbol: string}> 
-    marginIsolatedTransfer(options: marginIsolatedTransfer): Promise<{tranId: string}> 
-    marginIsolatedTransferHistory(options: marginIsolatedTransferHistory): Promise<marginIsolatedTransferHistoryResponse> 
+    marginMaxBorrow(options: { asset: string, isolatedSymbol?: string, recvWindow?: number }): Promise<{ amount: string, borrowLimit: string }>
+    marginCreateIsolated(options: { base: string, quote: string, recvWindow?: number }): Promise<{ success: boolean, symbol: string }>
+    marginIsolatedTransfer(options: marginIsolatedTransfer): Promise<{ tranId: string }>
+    marginIsolatedTransferHistory(options: marginIsolatedTransferHistory): Promise<marginIsolatedTransferHistoryResponse>
   }
 
   export interface HttpError extends Error {
@@ -411,6 +411,12 @@ declare module 'binance-api-node' {
       pairs: string | string[],
       callback: (trade: Trade) => void,
     ) => ReconnectingWebSocketHandler
+    futuresLiquidationStream: (
+      symbol: string | string[],
+      callback: (forecOrder: ForceOrder) => void) => ReconnectingWebSocketHandler
+    allFuturesLiquidations: (
+      callback: (forecOrder: ForceOrder) => void) => ReconnectingWebSocketHandler
+
     user: (callback: (msg: UserDataStreamEvent) => void) => Promise<ReconnectingWebSocketHandler>
     marginUser: (callback: (msg: OutboundAccountInfo | ExecutionReport) => void) => Promise<ReconnectingWebSocketHandler>
     futuresUser: (callback: (msg: OutboundAccountInfo | ExecutionReport) => void) => Promise<ReconnectingWebSocketHandler>
@@ -1011,7 +1017,7 @@ declare module 'binance-api-node' {
   export interface PositionModeResult {
     dualSidePosition: boolean
   }
-  
+
   export interface IsolatedMarginAccount {
     assets: IsolatedAsset[]
     totalAssetOfBtc: string
@@ -1045,7 +1051,7 @@ declare module 'binance-api-node' {
     repayEnabled: boolean
     totalAsset: string
   }
-  
+
   export interface marginIsolatedTransfer {
     asset: string
     symbol: string
@@ -1078,5 +1084,19 @@ declare module 'binance-api-node' {
       transTo: "SPOT" | "ISOLATED_MARGIN"
     }[]
     total: number
+  }
+
+  export interface ForceOrder {
+    symbol: string
+    price: string
+    origQty: string
+    lastFilledQty: string
+    accumulatedQty: string
+    averagePrice: string
+    status: string
+    timeInForce: string
+    type: OrderType
+    side: OrderSide
+    time: number
   }
 }

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -343,7 +343,7 @@ const futuresLiquidations = (payload, cb, transform = true) => {
     cache.forEach(w => w.close(1000, 'Close handle was called', { keepClosed: true, ...options }))
 }
 
-const allFuturesLiquidations = (cb, transform = true) => {
+const futuresAllLiquidations = (cb, transform = true) => {
   const w = new openWebSocket(`${endpoints.futures}/!forceOrder@arr`)
 
   w.onmessage = msg => {
@@ -657,7 +657,7 @@ export default opts => {
     futuresAllTickers: (cb, transform) => allTickers(cb, transform, 'futures'),
     futuresAggTrades: (payload, cb, transform) => aggTrades(payload, cb, transform, 'futures'),
     futuresLiquidations,
-    allFuturesLiquidations,
+    futuresAllLiquidations,
     futuresUser: user(opts, 'futures'),
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -298,7 +298,7 @@ test('[WS] liquidations', t => {
 
 test('[FUTURES-WS] all liquidations', t => {
   return new Promise(resolve => {
-    client.ws.allFuturesLiquidations(liquidation => {
+    client.ws.futuresAllLiquidations(liquidation => {
       checkFields(t, liquidation, [
         'symbol',
         'price',

--- a/test/index.js
+++ b/test/index.js
@@ -275,6 +275,48 @@ test('[WS] aggregate trades', t => {
   })
 })
 
+test('[WS] liquidations', t => {
+  return new Promise(resolve => {
+    client.ws.futuresLiquidations('ETHBTC', liquidation => {
+      checkFields(t, liquidation, [
+        'symbol',
+        'price',
+        'origQty',
+        'lastFilledQty',
+        'accumulatedQty',
+        'averagePrice',
+        'status',
+        'timeInForce',
+        'type',
+        'side',
+        'time',
+      ])
+      resolve()
+    })
+  })
+})
+
+test('[FUTURES-WS] all liquidations', t => {
+  return new Promise(resolve => {
+    client.ws.allFuturesLiquidations(liquidation => {
+      checkFields(t, liquidation, [
+        'symbol',
+        'price',
+        'origQty',
+        'lastFilledQty',
+        'accumulatedQty',
+        'averagePrice',
+        'status',
+        'timeInForce',
+        'type',
+        'side',
+        'time',
+      ])
+      resolve()
+    })
+  })
+})
+
 test('[WS] userEvents', t => {
   const accountPayload = {
     e: 'outboundAccountInfo',


### PR DESCRIPTION
Added support for liquidation streams.
Tests will mostly timeout with 10s setup, since these liquidations do not happen all the time.