### PR TITLE
Update README.md to guide how to use with `react-native`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ For PRs or issues, head over to the [source repository](https://github.com/Ashla
 
 ### Installation
 
-    yarn add binance-api-node
+    yarn add binance-api-node crypto
+    
+#### React-Native
+
+    yarn add binance-api-node crypto-js
 
 ### Getting started
 

--- a/README.md
+++ b/README.md
@@ -19,22 +19,21 @@ Those additional steps reffers only to `react-native`.
 
 You'll have to modify `http-client.js` in your `node_modules`:
 
-    ```diff
-    -var _crypto = _interopRequireDefault(require("crypto"));
-    +var _cryptoJS = _interopRequireDefault(require("crypto-js"));
-    ```
+```diff
+- var _crypto = _interopRequireDefault(require("crypto"));
++ var _cryptoJS = _interopRequireDefault(require("crypto-js"));
 
-    ```diff
-    -      var signature = _crypto.default.createHmac('sha256', apiSecret).update(makeQueryString(_objectSpread({}, data, {
-    -        timestamp: timestamp
-    -      })).substr(1)).digest('hex');
-    +      var signature = _cryptoJS.algo.HMAC
-    +        .create(_cryptoJS.algo.SHA256, apiSecret)
-    +        .update(makeQueryString({ ...data, timestamp }).substr(1))
-    +        .digest('hex')
-    +        .finalize()
-    +        .toString()
-    ```
+
+-      var signature = _crypto.default.createHmac('sha256', apiSecret).update(makeQueryString(_objectSpread({}, data, {
+-        timestamp: timestamp
+-      })).substr(1)).digest('hex');
++      var signature = _cryptoJS.algo.HMAC
++        .create(_cryptoJS.algo.SHA256, apiSecret)
++        .update(makeQueryString({ ...data, timestamp }).substr(1))
++        .digest('hex')
++        .finalize()
++        .toString()
+```
 
 Then use [patch-package](https://github.com/ds300/patch-package) to create patch.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,31 @@ For PRs or issues, head over to the [source repository](https://github.com/Ashla
 #### React-Native
 
     yarn add binance-api-node crypto-js
+    
+Those additional steps reffers only to `react-native`.
+
+You'll have to modify `http-client.js` in your `node_modules`:
+
+    ```diff
+    -var _crypto = _interopRequireDefault(require("crypto"));
+    +var _cryptoJS = _interopRequireDefault(require("crypto-js"));
+    ```
+
+    ```diff
+    -      var signature = _crypto.default.createHmac('sha256', apiSecret).update(makeQueryString(_objectSpread({}, data, {
+    -        timestamp: timestamp
+    -      })).substr(1)).digest('hex');
+    +      var signature = _cryptoJS.algo.HMAC
+    +        .create(_cryptoJS.algo.SHA256, apiSecret)
+    +        .update(makeQueryString({ ...data, timestamp }).substr(1))
+    +        .digest('hex')
+    +        .finalize()
+    +        .toString()
+    ```
+
+Then use [patch-package](https://github.com/ds300/patch-package) to create patch.
+
+    npx patch-package binance-api-node
 
 ### Getting started
 


### PR DESCRIPTION
Hi! 

I added some guides on how to use the package with `react-native`.

I find this way much simpler than usage `react-native-crypto`.