### PR TITLE
Update Speed for Diff. Depth Stream & Partial Book Depth Streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -2422,7 +2422,10 @@ clean()
 #### depth
 
 Live depth market data feed. The first parameter can either
-be a single symbol string or an array of symbols.
+be a single symbol string or an array of symbols. If you wish
+to specify the update speed (can either be `1000ms` or `100ms`)
+of the stream then append the speed at the end of the symbol
+string as follows: `ETHBTC@100ms` 
 
 ```js
 client.ws.depth('ETHBTC', depth => {
@@ -2456,7 +2459,10 @@ client.ws.depth('ETHBTC', depth => {
 #### partialDepth
 
 Top levels bids and asks, pushed every second. Valid levels are 5, 10, or 20.
-Accepts an array of objects for multiple depths.
+Accepts an array of objects for multiple depths. If you wish
+to specify the update speed (can either be `1000ms` or `100ms`)
+of the stream then append the speed at the end of the symbol
+string as follows: `ETHBTC@100ms` 
 
 ```js
 client.ws.partialDepth({ symbol: 'ETHBTC', level: 10 }, depth => {

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -32,10 +32,11 @@ const futuresDepthTransform = m => ({
 
 const depth = (payload, cb, transform = true, variator) => {
   const cache = (Array.isArray(payload) ? payload : [payload]).map(symbol => {
+    const [symbolName, updateSpeed] = symbol.toLowerCase().split('@');
     const w = openWebSocket(
       `${
         variator === 'futures' ? endpoints.futures : endpoints.base
-      }/${symbol.toLowerCase()}@depth`,
+      }/${symbolName}@depth${updateSpeed ? `@${updateSpeed}` : ''}`,
     )
     w.onmessage = msg => {
       const obj = JSON.parse(msg.data)
@@ -79,10 +80,11 @@ const futuresPartDepthTransform = (level, m) => ({
 
 const partialDepth = (payload, cb, transform = true, variator) => {
   const cache = (Array.isArray(payload) ? payload : [payload]).map(({ symbol, level }) => {
+    const [symbolName, updateSpeed] = symbol.toLowerCase().split('@');
     const w = openWebSocket(
       `${
         variator === 'futures' ? endpoints.futures : endpoints.base
-      }/${symbol.toLowerCase()}@depth${level}`,
+      }/${symbolName}@depth${level}${updateSpeed ? `@${updateSpeed}` : ''}`,
     )
     w.onmessage = msg => {
       const obj = JSON.parse(msg.data)

--- a/test/index.js
+++ b/test/index.js
@@ -195,9 +195,35 @@ test('[WS] depth', t => {
   })
 })
 
+test('[WS] depth with update speed', t => {
+  return new Promise(resolve => {
+    client.ws.depth('ETHBTC@100ms', depth => {
+      checkFields(t, depth, [
+        'eventType',
+        'eventTime',
+        'firstUpdateId',
+        'finalUpdateId',
+        'symbol',
+        'bidDepth',
+        'askDepth',
+      ])
+      resolve()
+    })
+  })
+})
+
 test('[WS] partial depth', t => {
   return new Promise(resolve => {
     client.ws.partialDepth({ symbol: 'ETHBTC', level: 10 }, depth => {
+      checkFields(t, depth, ['lastUpdateId', 'bids', 'asks'])
+      resolve()
+    })
+  })
+})
+
+test('[WS] partial depth with update speed', t => {
+  return new Promise(resolve => {
+    client.ws.partialDepth({ symbol: 'ETHBTC@100ms', level: 10 }, depth => {
       checkFields(t, depth, ['lastUpdateId', 'bids', 'asks'])
       resolve()
     })


### PR DESCRIPTION
Pull request for issue: #350 

Adds the ability to specify the update speed for the depth and partial depth WebSocket streams by adding the speed at the end of the symbol name. Example: `ETHBTC@100ms`