### PR TITLE
Remove pricePrecision & quantityPrecision

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -588,11 +588,11 @@ declare module 'binance-api-node' {
     isSpotTradingAllowed: boolean
     ocoAllowed: boolean
     orderTypes: OrderType[]
+    permissions: TradingType[]
     quoteAsset: string
+    quoteAssetPrecision: string
     quoteCommissionPrecision: number
     quoteOrderQtyMarketAllowed: boolean
-    pricePrecision: number
-    quantityPrecision: number
     quotePrecision: number
     status: string
     symbol: string


### PR DESCRIPTION
[This PR](quantityPrecision) introduced `pricePrecision` and `quantityPrecision` but those values got already removed from Binance (there is a comment saying "// will be removed in future api versions (v4+)"): https://github.com/binance/binance-spot-api-docs/commit/9c797ada166f4941fb5e57780dadb37c54a7eacb

Here is a current snapshot from a "Symbol" retrieved via `client.exchangeInfo()`:

```json
{
  "baseAsset": "BNB",
  "baseAssetPrecision": 8,
  "baseCommissionPrecision": 8,
  "filters": [
    {
      "filterType": "PRICE_FILTER",
      "maxPrice": "100000.00000000",
      "minPrice": "0.00000010",
      "tickSize": "0.00000010"
    },
    {
      "avgPriceMins": 5,
      "filterType": "PERCENT_PRICE",
      "multiplierDown": "0.2",
      "multiplierUp": "5"
    },
    {
      "filterType": "LOT_SIZE",
      "maxQty": "100000.00000000",
      "minQty": "0.01000000",
      "stepSize": "0.01000000"
    },
    {
      "applyToMarket": true,
      "avgPriceMins": 5,
      "filterType": "MIN_NOTIONAL",
      "minNotional": "0.00010000"
    },
    {
      "filterType": "ICEBERG_PARTS",
      "limit": 10
    },
    {
      "filterType": "MARKET_LOT_SIZE",
      "maxQty": "8528.32329395",
      "minQty": "0.00000000",
      "stepSize": "0.00000000"
    },
    {
      "filterType": "MAX_NUM_ORDERS",
      "maxNumOrders": 200
    },
    {
      "filterType": "MAX_NUM_ALGO_ORDERS",
      "maxNumAlgoOrders": 5
    }
  ],
  "icebergAllowed": true,
  "isMarginTradingAllowed": true,
  "isSpotTradingAllowed": true,
  "ocoAllowed": true,
  "orderTypes": [
    "LIMIT",
    "LIMIT_MAKER",
    "MARKET",
    "STOP_LOSS_LIMIT",
    "TAKE_PROFIT_LIMIT"
  ],
  "permissions": [
    "SPOT",
    "MARGIN"
  ],
  "quoteAsset": "BTC",
  "quoteAssetPrecision": 8,
  "quoteCommissionPrecision": 8,
  "quoteOrderQtyMarketAllowed": true,
  "quotePrecision": 8,
  "status": "TRADING",
  "symbol": "BNBBTC"
}
```

Going forward we should also **sort the attributes** of payloads to have a better overview when something is missing.