### PR TITLE
Update tradeFee typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,12 +68,8 @@ declare module 'binance-api-node' {
   }
   export interface TradeFee {
     symbol: string
-    maker: number
-    taker: number
-  }
-  export interface TradeFeeResult {
-    tradeFee: TradeFee[]
-    success: boolean
+    makerCommission: number
+    takerCommission: number
   }
   export interface AggregatedTrade {
     aggId: number
@@ -245,7 +241,7 @@ declare module 'binance-api-node' {
   export interface Binance {
     getInfo(): GetInfo
     accountInfo(options?: { useServerTime: boolean }): Promise<Account>
-    tradeFee(options?: { useServerTime: boolean }): Promise<TradeFeeResult>
+    tradeFee(options?: { useServerTime: boolean }): Promise<TradeFee[]>
     aggTrades(options?: {
       symbol: string
       fromId?: string


### PR DESCRIPTION
@balthazar my TypeScript code crashed in production when updating from binance-api-node v0.10.35 to binance-api-node v0.10.40. 

I was checking why and noticed that the return types of `client.tradeFee` got changed in the Readme (https://github.com/Ashlar/binance-api-node/pull/384) but the TypeScript definitions were not updated. So I am updating them with this PR.

I also noticed that `tradeFee` was modified in this commit:
- https://github.com/Ashlar/binance-api-node/commit/35d944de5e01b1b248750cb9b5e5357b0e2bc50d

Are there any other big modifications which happened between v0.10.35 & v0.10.40 that are worth double checking the `index.d.ts` file?