### PR TITLE
Fixed type definitions for symbol filters.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -587,30 +587,22 @@ declare module 'binance-api-node' {
     limit: number
   }
 
-  export type SymbolFilterType =
-    | 'PRICE_FILTER'
-    | 'PERCENT_PRICE'
-    | 'LOT_SIZE'
-    | 'MIN_NOTIONAL'
-    | 'MAX_NUM_ORDERS'
-    | 'MAX_ALGO_ORDERS'
-
   export interface SymbolPriceFilter {
-    filterType: SymbolFilterType
+    filterType: 'PRICE_FILTER'
     minPrice: string
     maxPrice: string
     tickSize: string
   }
 
   export interface SymbolPercentPriceFilter {
-    filterType: SymbolFilterType
+    filterType: 'PERCENT_PRICE'
     multiplierDown: string
     multiplierUp: string
     avgPriceMins: number
   }
 
   export interface SymbolLotSizeFilter {
-    filterType: SymbolFilterType
+    filterType: 'LOT_SIZE'
     minQty: string
     maxQty: string
     stepSize: string
@@ -619,17 +611,17 @@ declare module 'binance-api-node' {
   export interface SymbolMinNotionalFilter {
     applyToMarket: boolean
     avgPriceMins: number
-    filterType: SymbolFilterType
+    filterType: 'MIN_NOTIONAL'
     minNotional: string
   }
 
   export interface SymbolMaxNumOrdersFilter {
-    filterType: SymbolFilterType
+    filterType: 'MAX_NUM_ORDERS'
     limit: number
   }
 
   export interface SymbolMaxAlgoOrdersFilter {
-    filterType: SymbolFilterType
+    filterType: 'MAX_ALGO_ORDERS'
     limit: number
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -162,8 +162,8 @@ declare module 'binance-api-node' {
   }
   
   export interface SetBNBBurnOptions {
-    spotBNBBurn: "true" | "false";
-    interestBNBBurn: "true" | "false"; 
+    spotBNBBurn: boolean;
+    interestBNBBurn: boolean; 
     recvWindow?: number;
  }
 
@@ -202,24 +202,25 @@ declare module 'binance-api-node' {
     responseTime?: string
   }
 
-  export type TransferType =
-    | 'MAIN_C2C'
-    | 'MAIN_UMFUTURE'
-    | 'MAIN_CMFUTURE'
-    | 'MAIN_MARGIN'
-    | 'MAIN_MINING'
-    | 'C2C_MAIN'
-    | 'C2C_UMFUTURE'
-    | 'C2C_MINING'
-    | 'UMFUTURE_MAIN'
-    | 'UMFUTURE_C2C'
-    | 'UMFUTURE_MARGIN'
-    | 'CMFUTURE_MAIN'
-    | 'MARGIN_MAIN'
-    | 'MARGIN_UMFUTURE'
-    | 'MINING_MAIN'
-    | 'MINING_UMFUTURE'
-    | 'MINING_C2C'
+  export enum TransferType {
+    MAIN_C2C = 'MAIN_C2C',
+    MAIN_UMFUTURE = 'MAIN_UMFUTURE',
+    MAIN_CMFUTURE = 'MAIN_CMFUTURE',
+    MAIN_MARGIN  = 'MAIN_MARGIN',
+    MAIN_MINING = 'MAIN_MINING',
+    C2C_MAIN = 'C2C_MAIN',
+    C2C_UMFUTURE = 'C2C_UMFUTURE',
+    C2C_MINING = 'C2C_MINING',
+    UMFUTURE_MAIN = 'UMFUTURE_MAIN',
+    UMFUTURE_C2C = 'UMFUTURE_C2C',
+    UMFUTURE_MARGIN = 'UMFUTURE_MARGIN',
+    CMFUTURE_MAIN = 'CMFUTURE_MAIN',
+    MARGIN_MAIN = 'MARGIN_MAIN',
+    MARGIN_UMFUTURE = 'MARGIN_UMFUTURE',
+    MINING_MAIN = 'MINING_MAIN',
+    MINING_UMFUTURE = 'MINING_UMFUTURE',
+    MINING_C2C = 'MINING_C2C' 
+  }
 
   export interface UniversalTransfer {
     type: TransferType
@@ -247,6 +248,11 @@ declare module 'binance-api-node' {
       tranId: number
       timestamp: number
     }[]
+  }
+
+  export enum MarginType {
+    ISOLATED = "ISOLATED",
+    CROSSED = "CROSSED"
   }
 
   export interface Binance {
@@ -395,7 +401,7 @@ declare module 'binance-api-node' {
     }): Promise<FuturesLeverageResult>
     futuresMarginType(options: {
       symbol: string
-      marginType: "ISOLATED" | "CROSSED"
+      marginType: MarginType
       recvWindow?: number
     }): Promise<FuturesMarginTypeResult>
     futuresIncome(options: {
@@ -564,14 +570,21 @@ declare module 'binance-api-node' {
     ONE_MONTH = '1M',
   }
 
-  export type RateLimitType = 'REQUEST_WEIGHT' | 'ORDERS'
+  export enum RateLimitType {
+    REQUEST_WEIGHT = 'REQUEST_WEIGHT',
+    ORDERS = 'ORDERS'
+  }
 
   export enum TradingType {
     MARGIN = 'MARGIN',
     SPOT = 'SPOT',
   }
 
-  export type RateLimitInterval = 'SECOND' | 'MINUTE' | 'DAY'
+  export enum RateLimitInterval {
+    SECOND = 'SECOND', 
+    MINUTE = 'MINUTE', 
+    DAY = 'DAY'
+  }
 
   export interface ExchangeInfoRateLimit {
     rateLimitType: RateLimitType
@@ -580,7 +593,10 @@ declare module 'binance-api-node' {
     limit: number
   }
 
-  export type ExchangeFilterType = 'EXCHANGE_MAX_NUM_ORDERS' | 'EXCHANGE_MAX_ALGO_ORDERS'
+  export enum ExchangeFilterType {
+    EXCHANGE_MAX_NUM_ORDERS = 'EXCHANGE_MAX_NUM_ORDERS',
+    EXCHANGE_MAX_ALGO_ORDERS = 'EXCHANGE_MAX_ALGO_ORDERS' 
+  }
 
   export interface ExchangeFilter {
     filterType: ExchangeFilterType
@@ -715,7 +731,11 @@ declare module 'binance-api-node' {
     useServerTime?: boolean
   }
 
-  export type SideEffectType = 'NO_SIDE_EFFECT' | 'MARGIN_BUY' | 'AUTO_REPAY'
+  export enum SideEffectType {
+    NO_SIDE_EFFECT = 'NO_SIDE_EFFECT',
+    MARGIN_BUY = 'MARGIN_BUY',
+    AUTO_REPAY = 'AUTO_REPAY' 
+  }
 
   export interface OrderFill {
     tradeId: number
@@ -744,9 +764,25 @@ declare module 'binance-api-node' {
     fills?: OrderFill[]
   }
 
+  export enum ListOrderStatus {
+    EXECUTING ='EXECUTING',
+    ALL_DONE = 'ALL_DONE',
+    REJECT = 'REJECT'
+  } 
+
+  export enum ListStatusType {
+    RESPONSE = 'RESPONSE',
+    EXEC_STARTED = 'EXEC_STARTED',
+    ALL_DONE = 'ALL_DONE'
+  }
+
+  export enum OcoOrderType {
+    CONTINGENCY_TYPE = 'OCO',
+  } 
+
   export interface OcoOrder {
     orderListId: number
-    contingencyType: ContingencyType
+    contingencyType: OcoOrderType.CONTINGENCY_TYPE
     listStatusType: ListStatusType
     listOrderStatus: ListOrderStatus
     listClientOrderId: string
@@ -756,35 +792,42 @@ declare module 'binance-api-node' {
     orderReports: Order[]
   }
 
-  export type OrderSide = 'BUY' | 'SELL'
+  export enum OrderSide {
+    BUY = 'BUY',
+    SELL = 'SELL'
+  }
 
-  export type OrderStatus =
-    | 'CANCELED'
-    | 'EXPIRED'
-    | 'FILLED'
-    | 'NEW'
-    | 'PARTIALLY_FILLED'
-    | 'PENDING_CANCEL'
-    | 'REJECTED'
+  export enum OrderStatus {
+    CANCELED = 'CANCELED',
+    EXPIRED = 'EXPIRED',
+    FILLED = 'FILLED',
+    NEW = 'NEW',
+    PARTIALLY_FILLED = 'PARTIALLY_FILLED',
+    PENDING_CANCEL = 'PENDING_CANCEL',
+    REJECTED = 'REJECTED'
+  }
 
-  export type OrderType =
-    | 'LIMIT'
-    | 'LIMIT_MAKER'
-    | 'MARKET'
-    | 'STOP'
-    | 'STOP_MARKET'
-    | 'TAKE_PROFIT_MARKET'
-    | 'TRAILING_STOP_MARKET'
+  export enum OrderType {
+  LIMIT = 'LIMIT',
+  LIMIT_MAKER = 'LIMIT_MAKER',
+  MARKET = 'MARKET',
+  STOP = 'STOP',
+  STOP_MARKET ='STOP_MARKET',
+  TAKE_PROFIT_MARKET = 'TAKE_PROFIT_MARKET',
+  TRAILING_STOP_MARKET = 'TRAILING_STOP_MARKET'
+  }
 
-  export type ListOrderStatus = 'EXECUTING' | 'ALL_DONE' | 'REJECT'
+  export enum NewOrderRespType {
+    ACK = 'ACK',
+    RESULT = 'RESULT',
+    FULL = 'FULL'
+  }
 
-  export type ListStatusType = 'RESPONSE' | 'EXEC_STARTED' | 'ALL_DONE'
-
-  export type ContingencyType = 'OCO'
-
-  export type NewOrderRespType = 'ACK' | 'RESULT' | 'FULL'
-
-  export type TimeInForce = 'GTC' | 'IOC' | 'FOK'
+  export enum TimeInForce {
+    GTC = 'GTC',
+    IOC = 'IOC',
+    FOK = 'FOK'
+  } 
 
   export enum OrderRejectReason {
     ACCOUNT_CANNOT_SETTLE = 'ACCOUNT_CANNOT_SETTLE',
@@ -800,7 +843,14 @@ declare module 'binance-api-node' {
     UNKNOWN_ORDER = 'UNKNOWN_ORDER',
   }
 
-  export type ExecutionType = 'NEW' | 'CANCELED' | 'REPLACED' | 'REJECTED' | 'TRADE' | 'EXPIRED'
+  export enum ExecutionType {
+    NEW = 'NEW',
+    CANCELED ='CANCELED',
+    REPLACED = 'REPLACED', 
+    REJECTED = 'REJECTED',
+    TRADE = 'TRADE', 
+    EXPIRED = 'EXPIRED'
+  }
 
   export interface Depth {
     eventType: string
@@ -900,6 +950,14 @@ declare module 'binance-api-node' {
     }
   }
 
+  export enum EventType {
+    ACCOUNT = 'account',
+    BALANCE_UPDATE = 'balanceUpdate',
+    OUTBOUND_ACCOUNT_POSITION = 'outboundAccountPosition',
+    EXECUTION_REPORT = 'executionReport',
+    ACCOUNT_UPDATE = 'ACCOUNT_UPDATE'
+  }
+
   export interface OutboundAccountInfo {
     balances: Balances
     makerCommissionRate: number
@@ -910,7 +968,7 @@ declare module 'binance-api-node' {
     canWithdraw: boolean
     canDeposit: boolean
     lastAccountUpdate: number
-    eventType: 'account'
+    eventType: EventType.ACCOUNT
     eventTime: number
   }
 
@@ -919,13 +977,13 @@ declare module 'binance-api-node' {
     balanceDelta: string
     clearTime: number
     eventTime: number
-    eventType: 'balanceUpdate'
+    eventType: EventType.BALANCE_UPDATE
   }
 
   export interface OutboundAccountPosition {
     balances: AssetBalance[]
     eventTime: number
-    eventType: 'outboundAccountPosition'
+    eventType: EventType.OUTBOUND_ACCOUNT_POSITION
     lastAccountUpdate: number
   }
 
@@ -934,7 +992,7 @@ declare module 'binance-api-node' {
     commissionAsset: string | null // Commission asset
     creationTime: number // Order creation time
     eventTime: number
-    eventType: 'executionReport'
+    eventType: EventType.EXECUTION_REPORT
     executionType: ExecutionType // Current execution type
     icebergQuantity: string // Iceberg quantity
     isBuyerMaker: boolean // Is this trade the maker side?
@@ -981,7 +1039,7 @@ declare module 'binance-api-node' {
 
   export interface AccountUpdate {
     eventTime: string
-    eventType: 'ACCOUNT_UPDATE'
+    eventType: EventType.ACCOUNT_UPDATE
     transactionTime: number
     eventReasonType: string
     balances: Balance[]
@@ -1215,13 +1273,14 @@ declare module 'binance-api-node' {
     msg: string
   }
 
-  export type FuturesIncomeType =
-    | 'TRANSFER'
-    | 'WELCOME_BONUS'
-    | 'REALIZED_PNL'
-    | 'FUNDING_FEE'
-    | 'COMMISSION'
-    | 'INSURANCE_CLEAR'
+  export enum FuturesIncomeType {
+    TRANSFER = 'TRANSFER',
+    WELCOME_BONUS = 'WELCOME_BONUS',
+    REALIZED_PNL = 'REALIZED_PNL',
+    FUNDING_FEE = 'FUNDING_FEE',
+    COMMISSION = 'COMMISSION',
+    INSURANCE_CLEAR = 'INSURANCE_CLEAR'
+  }
 
   export interface FuturesIncomeResult {
     symbol: string
@@ -1250,18 +1309,21 @@ declare module 'binance-api-node' {
     totalNetAssetOfBtc: string
   }
 
+  export enum MarginLevelStatus {
+    EXCESSIVE = 'EXCESSIVE',
+    NORMAL = 'NORMAL',
+    MARGIN_CALL = 'MARGIN_CALL',
+    PRE_LIQUIDATION = 'PRE_LIQUIDATION',
+    FORCE_LIQUIDATION = 'FORCE_LIQUIDATION'
+  }
+
   export interface IsolatedAsset {
     baseAsset: IsolatedAssetSingle
     quoteAsset: IsolatedAssetSingle
     symbol: string
     isolatedCreated: boolean
     marginLevel: string
-    marginLevelStatus:
-      | 'EXCESSIVE'
-      | 'NORMAL'
-      | 'MARGIN_CALL'
-      | 'PRE_LIQUIDATION'
-      | 'FORCE_LIQUIDATION'
+    marginLevelStatus: MarginLevelStatus
     marginRatio: string
     indexPrice: string
     liquidatePrice: string
@@ -1282,11 +1344,16 @@ declare module 'binance-api-node' {
     totalAsset: string
   }
 
+  export enum WalletType {
+    SPOT = 'SPOT',
+    ISOLATED_MARGIN ='ISOLATED_MARGIN'
+  }
+
   export interface marginIsolatedTransfer {
     asset: string
     symbol: string
-    transFrom: 'SPOT' | 'ISOLATED_MARGIN'
-    transTo: 'SPOT' | 'ISOLATED_MARGIN'
+    transFrom: WalletType
+    transTo: WalletType
     amount: number
     recvWindow?: number
   }
@@ -1294,8 +1361,8 @@ declare module 'binance-api-node' {
   export interface marginIsolatedTransferHistory {
     asset?: string
     symbol: string
-    transFrom?: 'SPOT' | 'ISOLATED_MARGIN'
-    transTo?: 'SPOT' | 'ISOLATED_MARGIN'
+    transFrom?: WalletType
+    transTo?: WalletType
     startTime?: number
     endTime?: number
     current?: number
@@ -1310,8 +1377,8 @@ declare module 'binance-api-node' {
       status: string
       timestamp: number
       txId: number
-      transFrom: 'SPOT' | 'ISOLATED_MARGIN'
-      transTo: 'SPOT' | 'ISOLATED_MARGIN'
+      transFrom: WalletType
+      transTo: WalletType
     }[]
     total: number
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -587,41 +587,50 @@ declare module 'binance-api-node' {
     limit: number
   }
 
+  export enum SymbolFilterType {
+    PRICE_FILTER = 'PRICE_FILTER',
+    PERCENT_PRICE = 'PERCENT_PRICE',
+    LOT_SIZE = 'LOT_SIZE',
+    MIN_NOTIONAL = 'MIN_NOTIONAL',
+    MAX_NUM_ORDERS = 'MAX_NUM_ORDERS',
+    MAX_ALGO_ORDERS = 'MAX_ALGO_ORDERS'
+  }
+
   export interface SymbolPriceFilter {
-    filterType: 'PRICE_FILTER'
+    filterType: SymbolFilterType.PRICE_FILTER
     minPrice: string
     maxPrice: string
     tickSize: string
   }
 
   export interface SymbolPercentPriceFilter {
-    filterType: 'PERCENT_PRICE'
+    filterType: SymbolFilterType.PERCENT_PRICE
     multiplierDown: string
     multiplierUp: string
     avgPriceMins: number
   }
 
   export interface SymbolLotSizeFilter {
-    filterType: 'LOT_SIZE'
+    filterType: SymbolFilterType.LOT_SIZE
     minQty: string
     maxQty: string
     stepSize: string
   }
 
   export interface SymbolMinNotionalFilter {
+    filterType: SymbolFilterType.MIN_NOTIONAL
     applyToMarket: boolean
     avgPriceMins: number
-    filterType: 'MIN_NOTIONAL'
     minNotional: string
   }
 
   export interface SymbolMaxNumOrdersFilter {
-    filterType: 'MAX_NUM_ORDERS'
+    filterType: SymbolFilterType.MAX_NUM_ORDERS
     limit: number
   }
 
   export interface SymbolMaxAlgoOrdersFilter {
-    filterType: 'MAX_ALGO_ORDERS'
+    filterType: SymbolFilterType.MAX_ALGO_ORDERS
     limit: number
   }
 


### PR DESCRIPTION
**This PR does the following changes in brief:**
- Updates the type definition for `Symbol.filters`

**Details:**

The previous type definition for filters to support discriminated union didn't work because to allow typescript to choose the correct interface two rules need to be followed:
1) There should be a common member between the interfaces.
2) The **value** of the common member should be unique per interface.

The definition was not following (2) as a result Typescript was failing with Type Errors.
![Screenshot from 2021-05-23 16-22-06](https://user-images.githubusercontent.com/28751271/119264658-59e43e00-bbe4-11eb-928e-25fa548988aa.png)

This PR remedies (2) by moving the `filterType` values into their respective interfaces.