### PR TITLE
Fixes missing `Futures Public REST Endpoints` h3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,8 @@ console.log(await client.allBookTickers())
 
 </details>
 
+### Futures Public REST Endpoints
+
 #### futures ping
 
 Test connectivity to the API.


### PR DESCRIPTION
Clicking Futures Public REST Endpoints wasn't working. It was missing the `### Futures Public REST Endpoints` header