### PR TITLE
Add marginGetOrder

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Following examples will use the `await` form, which requires some configuration 
   - [marginCreateIsolated](#marginCreateIsolated)
   - [marginIsolatedTransfer](#marginIsolatedTransfer)
   - [marginIsolatedTransferHistory](#marginIsolatedTransferHistory)
+  - [marginOrder](#marginorder)
+  - [marginGetOrder](#margingetorder)
 - [Futures Authenticated REST Endpoints](#futures-authenticated-rest-endpoints)
   - [futuresGetOrder](#futuresGetOrder)
   - [futuresAllOrders](#futuresAllOrders)
@@ -2478,6 +2480,137 @@ console.log(await client.marginIsolatedTransferHistory({ symbol: 'BNBUSDT'}));
     }
   ],
   "total": 2
+}
+```
+
+</details>
+
+#### marginOrder
+
+```js
+console.log(await client.marginOrder({ 
+  symbol: 'BTCUSDT', 
+  type: 'MARKET',
+  side: 'SELL',
+  quantity: '10',
+  }));
+```
+
+| Param             | Type    | Required | Description               |
+| ----------------- | ------- | -------- | ------------------------- |
+| symbol            | String  | true     | asset, such as `BTC`      |
+| isIsolated        | String  | false    | for isolated margin or not, `TRUE`, `FALSE`, default `FALSE`
+| side              | String  | true     | `BUY` `SELL` |
+| type              | String  | true     |  
+| quantity          | String  | false    |
+| quoteOrderQty     | String  | false    |
+| price             | String  | false    | 
+| stopPrice         | String  | false    | Used with `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, and `TAKE_PROFIT_LIMIT` orders.
+| newClientOrderId  | NuStringmber  | false    | A unique id among open orders. Automatically generated if not sent.
+| icebergQty        | Boolean | false    | Used with `LIMIT`, `STOP_LOSS_LIMIT`, and `TAKE_PROFIT_LIMIT` to create an iceberg order.
+| newOrderRespType  | String  | false    | Set the response JSON. `ACK`, `RESULT`, or `FULL`; `MARKET` and `LIMIT` order types default to `FULL`, all other orders default to `ACK`.
+| sideEffectType    | String  | false    | `NO_SIDE_EFFECT`, `MARGIN_BUY`, `AUTO_REPAY`; default `NO_SIDE_EFFECT`.
+| timeInForce       | String  | false    | `GTC`,`IOC`,`FOK`        |
+| recvWindow        | Number  | false    | No more than 60000        |
+
+<details>
+<summary>Output</summary>
+    
+```js
+{
+  "symbol": "BTCUSDT",
+  "orderId": 28,
+  "clientOrderId": "6gCrw2kRUAF9CvJDGP16IP",
+  "transactTime": 1507725176595,
+  "price": "1.00000000",
+  "origQty": "10.00000000",
+  "executedQty": "10.00000000",
+  "cummulativeQuoteQty": "10.00000000",
+  "status": "FILLED",
+  "timeInForce": "GTC",
+  "type": "MARKET",
+  "side": "SELL",
+  "marginBuyBorrowAmount": 5,       // will not return if no margin trade happens
+  "marginBuyBorrowAsset": "BTC",    // will not return if no margin trade happens
+  "isIsolated": true,       // if isolated margin
+  "fills": [
+    {
+      "price": "4000.00000000",
+      "qty": "1.00000000",
+      "commission": "4.00000000",
+      "commissionAsset": "USDT"
+    },
+    {
+      "price": "3999.00000000",
+      "qty": "5.00000000",
+      "commission": "19.99500000",
+      "commissionAsset": "USDT"
+    },
+    {
+      "price": "3998.00000000",
+      "qty": "2.00000000",
+      "commission": "7.99600000",
+      "commissionAsset": "USDT"
+    },
+    {
+      "price": "3997.00000000",
+      "qty": "1.00000000",
+      "commission": "3.99700000",
+      "commissionAsset": "USDT"
+    },
+    {
+      "price": "3995.00000000",
+      "qty": "1.00000000",
+      "commission": "3.99500000",
+      "commissionAsset": "USDT"
+    }
+  ]
+}
+```
+
+</details>
+
+#### marginGetOrder
+
+Query Margin Account's Order
+
+```js
+console.log(await client.marginGetOrder({ 
+  symbol: 'BNBBTC', 
+  orderId: '213205622',
+  }));
+```
+
+| Param                | Type   | Required | Description               |
+| -------------------- | ------ | -------- | ------------------------- |
+| symbol               | String | true     | asset,such as BTC         |
+| isIsolated           | String | false    | for isolated margin or not, `TRUE`, `FALSE`, default `FALSE`
+| orderId              | String | false    | 
+| origClientOrderId    | String | false    | 
+| recvWindow           | Number | false    | The value cannot be greater than `60000`
+
+<details>
+<summary>Output</summary>
+    
+```js
+{
+   "clientOrderId": "ZwfQzuDIGpceVhKW5DvCmO",
+   "cummulativeQuoteQty": "0.00000000",
+   "executedQty": "0.00000000",
+   "icebergQty": "0.00000000",
+   "isWorking": true,
+   "orderId": 213205622,
+   "origQty": "0.30000000",
+   "price": "0.00493630",
+   "side": "SELL",
+   "status": "NEW",
+   "stopPrice": "0.00000000",
+   "symbol": "BNBBTC",
+   "isIsolated": true,
+   "time": 1562133008725,
+   "timeInForce": "GTC",
+   "type": "LIMIT",
+   "updateTime": 1562133008725
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Following examples will use the `await` form, which requires some configuration 
   - [marginCreateIsolated](#marginCreateIsolated)
   - [marginIsolatedTransfer](#marginIsolatedTransfer)
   - [marginIsolatedTransferHistory](#marginIsolatedTransferHistory)
-  - [marginOrder](#marginorder)
-  - [marginGetOrder](#margingetorder)
+  - [marginOrder](#marginOrder)
+  - [marginGetOrder](#marginGetOrder)
 - [Futures Authenticated REST Endpoints](#futures-authenticated-rest-endpoints)
   - [futuresGetOrder](#futuresGetOrder)
   - [futuresAllOrders](#futuresAllOrders)
@@ -2506,7 +2506,7 @@ console.log(await client.marginOrder({
 | quoteOrderQty     | String  | false    |
 | price             | String  | false    | 
 | stopPrice         | String  | false    | Used with `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, and `TAKE_PROFIT_LIMIT` orders.
-| newClientOrderId  | NuStringmber  | false    | A unique id among open orders. Automatically generated if not sent.
+| newClientOrderId  | String  | false    | A unique id among open orders. Automatically generated if not sent.
 | icebergQty        | Boolean | false    | Used with `LIMIT`, `STOP_LOSS_LIMIT`, and `TAKE_PROFIT_LIMIT` to create an iceberg order.
 | newOrderRespType  | String  | false    | Set the response JSON. `ACK`, `RESULT`, or `FULL`; `MARKET` and `LIMIT` order types default to `FULL`, all other orders default to `ACK`.
 | sideEffectType    | String  | false    | `NO_SIDE_EFFECT`, `MARGIN_BUY`, `AUTO_REPAY`; default `NO_SIDE_EFFECT`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -790,7 +790,7 @@ declare module 'binance-api-node' {
     stopPrice?: string
     symbol: string
     timeInForce: TimeInForce
-    transactTime: number
+    transactTime?: number
     type: OrderType
     fills?: OrderFill[]
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -432,6 +432,13 @@ declare module 'binance-api-node' {
       recvWindow?: number
     }): Promise<FuturesIncomeResult[]>
     marginOrder(options: NewOrder): Promise<Order>
+    marginGetOrder(options: {
+      symbol: string
+      isIsolated?: string | boolean
+      orderId?: string
+      origClientOrderId?: string
+      recvWindow?: number
+    }): Promise<Order>
     marginAllOrders(options: {
       symbol: string
       useServerTime?: boolean
@@ -476,7 +483,7 @@ declare module 'binance-api-node' {
     ): Promise<marginIsolatedTransferHistoryResponse>
     marginMyTrades(options: {
       symbol: string
-      isIsolated?: string
+      isIsolated?: string | boolean
       startTime?: number
       endTime?: number
       limit?: number
@@ -729,7 +736,7 @@ declare module 'binance-api-node' {
     useServerTime?: boolean
     type: OrderType
     newOrderRespType?: NewOrderRespType
-    isIsolated?: boolean
+    isIsolated?: string | boolean
     quoteOrderQty?: string
     sideEffectType?: SideEffectType
     reduceOnly?: string

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -361,7 +361,6 @@ export default opts => {
     accountSnapshot: payload => privCall('/sapi/v1/accountSnapshot', payload),
     universalTransfer: payload => privCall('/sapi/v1/asset/transfer', payload, 'POST'),
     universalTransferHistory: payload => privCall('/sapi/v1/asset/transfer', payload),
-    assetDetail: payload => privCall('/sapi/v1/asset/assetDetail', payload),
 
     dustTransfer: payload => privCall('/sapi/v1/asset/dust', payload, 'POST'),
     accountCoins: payload => privCall('/sapi/v1/capital/config/getall', payload),
@@ -388,6 +387,7 @@ export default opts => {
 
     marginAllOrders: payload => privCall('/sapi/v1/margin/allOrders', payload),
     marginOrder: payload => order(privCall, payload, '/sapi/v1/margin/order'),
+    marginGetOrder: payload => privCall('/sapi/v1/margin/order', payload),
     marginCancelOrder: payload => privCall('/sapi/v1/margin/order', payload, 'DELETE'),
     marginOpenOrders: payload => privCall('/sapi/v1/margin/openOrders', payload),
     marginAccountInfo: payload => privCall('/sapi/v1/margin/account', payload),


### PR DESCRIPTION
Hi @balthazar 
I hope you are doing good.

I add a new method - marginGetOrder.

Also, I fixed several things:
- Add marginOrder description to README.md
- Remove double assetDetail from http-client.js
- For isIsolated field, I add `string | boolean` type. According to Binance documentation it must be string, but Binance kindly accepts boolean too. So I keep boolean for back compability.