### PR TITLE
fix: force base API endpoint for /sapi

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -115,7 +115,7 @@ const publicCall = ({ endpoints }) => (path, data, method = 'GET', headers = {})
   sendResult(
     fetch(
       `${
-        !(path.includes('/fapi') || path.includes('/futures')) ? endpoints.base : endpoints.futures
+        !(path.includes('/fapi') || path.includes('/futures')) || path.includes('/sapi') ? endpoints.base : endpoints.futures
       }${path}${makeQueryString(data)}`,
       {
         method,
@@ -181,7 +181,7 @@ const privateCall = ({ apiKey, apiSecret, endpoints, getTime = defaultGetTime, p
     return sendResult(
       fetch(
         `${
-          !(path.includes('/fapi') || path.includes('/futures'))
+          !(path.includes('/fapi') || path.includes('/futures')) || path.includes('/sapi')
             ? endpoints.base
             : endpoints.futures
         }${path}${noData ? '' : makeQueryString(newData)}`,


### PR DESCRIPTION
Hi,

this change avoids that endpoints like `/sapi/v1/broker/subAccount/futures` are mistakenly directed to fapi. instead of api.

Specifically, it is the check `path.includes('/futures')` that makes that condition false and therefore uses the futures endpoint instead of the base endpoint.