### PR TITLE
Add lendingAccount & fundingWallet endpoints implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Following examples will use the `await` form, which requires some configuration 
   - [dustLog](#dustlog)
   - [dustTransfer](#dustTransfer)
   - [accountCoins](#accountCoins)
+  - [lendingAccount](#lendingAccount)
+  - [fundingWallet](#fundingWallet)
 - [Margin](#margin)
   - [marginAccountInfo](#marginAccountInfo)
   - [marginLoan](#marginLoan)
@@ -1902,7 +1904,6 @@ console.log(await client.capitalConfigs())
 
 </details>
 
-
 #### universalTransfer
 
 You need to enable Permits Universal Transfer option for the api key which requests this endpoint.
@@ -2248,6 +2249,75 @@ console.log(await client.accountCoins())
         "trading": true,
         "withdrawAllEnable": true,
         "withdrawing": "0.00000000"
+    }
+]
+```
+
+</details>
+
+#### lendingAccount
+
+Get information of lending assets for user.
+
+```js
+console.log(await client.lendingAccount())
+```
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+    "positionAmountVos": [
+        {
+            "amount": "75.46000000",
+            "amountInBTC": "0.01044819",
+            "amountInUSDT": "75.46000000",
+            "asset": "USDT"
+        },
+        {
+            "amount": "1.67072036",
+            "amountInBTC": "0.00023163",
+            "amountInUSDT": "1.67289230",
+            "asset": "BUSD"
+        }
+    ],
+    "totalAmountInBTC": "0.01067982",
+    "totalAmountInUSDT": "77.13289230",
+    "totalFixedAmountInBTC": "0.00000000",
+    "totalFixedAmountInUSDT": "0.00000000",
+    "totalFlexibleInBTC": "0.01067982",
+    "totalFlexibleInUSDT": "77.13289230"
+ }
+```
+
+</details>
+
+#### fundingWallet
+
+Query funding wallet, includes Binance Pay, Binance Card, Binance Gift Card, Stock Token.
+
+```js
+console.log(await client.fundingWallet())
+```
+
+| Param      | Type     | Required | Description         |
+| ---------- | -------- | -------- | ------------------- |
+| asset      | STRING   | false    |
+| needBtcValuation      | STRING   | false    | 'true' or 'false'
+
+<details>
+<summary>Output</summary>
+
+```js
+[
+    {
+        "asset": "USDT",
+        "free": "1",
+        "locked": "0",
+        "freeze": "0",
+        "withdrawing": "0",  
+        "btcValuation": "0.00000091"  
     }
 ]
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -89,6 +89,32 @@ declare module 'binance-api-node' {
     locked: string
   }
 
+  export interface positionAmount {
+    amount: string
+    amountInBTC: string
+    amountInUSDT: string
+    asset: string
+  }
+
+  export interface LendingAccount {
+    positionAmountVos: positionAmount[]
+    totalAmountInBTC: string
+    totalAmountInUSDT: string
+    totalFixedAmountInBTC: string
+    totalFixedAmountInUSDT: string
+    totalFlexibleInBTC: string
+    totalFlexibleInUSDT: string
+  }
+
+  export interface FundingWallet {
+    asset: string
+    free: string    // avalible balance
+    locked: string  // locked asset
+    freeze: string  // freeze asset
+    withdrawing: string
+    btcValuation: string
+  }
+
   export interface DepositAddress {
     address: string
     tag: string
@@ -307,6 +333,8 @@ declare module 'binance-api-node' {
     allBookTickers(): Promise<{ [key: string]: Ticker }>
     book(options: { symbol: string; limit?: number }): Promise<OrderBook>
     exchangeInfo(): Promise<ExchangeInfo>
+    lendingAccount(options?: { useServerTime: boolean }): Promise<LendingAccount>
+    fundingWallet(options?: { asset?: string, needBtcValuation?: booleanString, useServerTime?: boolean }): Promise<FundingWallet[]>
     order(options: NewOrderSpot): Promise<Order>
     orderTest(options: NewOrderSpot): Promise<Order>
     orderOco(options: NewOcoOrder): Promise<OcoOrder>

--- a/index.d.ts
+++ b/index.d.ts
@@ -110,7 +110,7 @@ declare module 'binance-api-node' {
 
   export interface FundingWallet {
     asset: string
-    free: string    // avalible balance
+    free: string    // available balance
     locked: string  // locked asset
     freeze: string  // freeze asset
     withdrawing: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -89,6 +89,8 @@ declare module 'binance-api-node' {
     locked: string
   }
 
+  export type booleanString = 'true' | 'false'
+
   export interface positionAmount {
     amount: string
     amountInBTC: string

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -447,5 +447,7 @@ export default opts => {
     futuresPositionMargin: payload => privCall('/fapi/v1/positionMargin', payload, 'POST'),
     futuresMarginHistory: payload => privCall('/fapi/v1/positionMargin/history', payload),
     futuresIncome: payload => privCall('/fapi/v1/income', payload),
+    lendingAccount: payload => privCall('/sapi/v1/lending/union/account', payload),
+    binanceCard: payload => privCall('/sapi/v1/asset/get-funding-asset', payload, 'POST'),
   }
 }

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -448,6 +448,6 @@ export default opts => {
     futuresMarginHistory: payload => privCall('/fapi/v1/positionMargin/history', payload),
     futuresIncome: payload => privCall('/fapi/v1/income', payload),
     lendingAccount: payload => privCall('/sapi/v1/lending/union/account', payload),
-    binanceCard: payload => privCall('/sapi/v1/asset/get-funding-asset', payload, 'POST'),
+    fundingWallet: payload => privCall('/sapi/v1/asset/get-funding-asset', payload, 'POST'),
   }
 }


### PR DESCRIPTION
Closes #482 by implementing
- [Lending Account (USER_DATA)](https://binance-docs.github.io/apidocs/spot/en/#lending-account-user_data) endpoint
- [Funding Wallet (USER_DATA)](https://binance-docs.github.io/apidocs/spot/en/#funding-wallet-user_data) endpoint
- Corresponding data types for TypeScript