### PR TITLE
Add optional symbol parameter to futuresPositionRisk

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -508,7 +508,10 @@ declare module 'binance-api-node' {
       symbol?: string
       useServerTime?: boolean
     }): Promise<QueryOrderResult[]>
-    futuresPositionRisk(options?: { recvWindow: number }): Promise<PositionRiskResult[]>
+    futuresPositionRisk(options?: {
+      symbol?: string
+      recvWindow?: number
+    }): Promise<PositionRiskResult[]>
     futuresLeverageBracket(options?: {
       symbol?: string
       recvWindow: number


### PR DESCRIPTION
Add missing symbol parameter to futuresPositionRisk.
Make recvWindow optional.

[https://binance-docs.github.io/apidocs/futures/en/#position-information-v2-user_data](https://binance-docs.github.io/apidocs/futures/en/#position-information-v2-user_data)

