### PR TITLE
Create disableMarginAccount method

### DIFF
--- a/README.md
+++ b/README.md
@@ -2540,6 +2540,31 @@ console.log(await client.marginIsolatedAccount({ symbols: 'BTCUSDT'}));
 
 </details>
 
+#### disableMarginAccount
+
+Inactive Isolated Margin trading pair for symbol
+
+```js
+console.log(await client.disableMarginAccount({ symbol: 'BTCUSDT'}));
+```
+
+| Param | Type   | Required | Description    |
+| ----- | ------ | -------- | -------------- |
+| symbol | String | true     |  |
+| recvWindow | Number | false     | No more than 60000 |
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+   "success": true,
+   "symbol": "BTCUSDT"
+}
+```
+
+</details>
+
 #### marginMaxBorrow
 
 If isolatedSymbol is not sent, crossed margin data will be sent.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Following examples will use the `await` form, which requires some configuration 
   - [marginIsolatedTransfer](#marginIsolatedTransfer)
   - [marginIsolatedTransferHistory](#marginIsolatedTransferHistory)
   - [marginOrder](#marginOrder)
+  - [marginOrderOco](#marginOrderOco)
   - [marginGetOrder](#marginGetOrder)
 - [Futures Authenticated REST Endpoints](#futures-authenticated-rest-endpoints)
   - [futuresGetOrder](#futuresGetOrder)
@@ -2742,6 +2743,98 @@ console.log(await client.marginOrder({
       "qty": "1.00000000",
       "commission": "3.99500000",
       "commissionAsset": "USDT"
+    }
+  ]
+}
+```
+
+</details>
+
+#### marginOrderOco
+
+```js
+console.log(await client.marginOrderOco({ 
+  symbol: 'AUDIOUSDT', 
+  type: 'MARKET',
+  side: 'SELL',
+  quantity: '10',
+  }));
+```
+
+| Param             | Type    | Required | Description               |
+| ----------------- | ------- | -------- | ------------------------- |
+| symbol            | String  | true     | asset, such as `BTC`      |
+| isIsolated        | String  | false    | for isolated margin or not, `TRUE`, `FALSE`, default `FALSE`
+| side              | String  | true     | `BUY` `SELL` |
+| type              | String  | true     |  
+| quantity          | String  | false    |
+| quoteOrderQty     | String  | false    |
+| price             | String  | false    | 
+| stopPrice         | String  | false    | Used with `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, and `TAKE_PROFIT_LIMIT` orders.
+| stopLimitPrice    | String  | false    | Used with `STOP_LOSS_LIMIT` orders.
+| newClientOrderId  | String  | false    | A unique id among open orders. Automatically generated if not sent.
+| icebergQty        | Boolean | false    | Used with `LIMIT`, `STOP_LOSS_LIMIT`, and `TAKE_PROFIT_LIMIT` to create an iceberg order.
+| newOrderRespType  | String  | false    | Set the response JSON. `ACK`, `RESULT`, or `FULL`; `MARKET` and `LIMIT` order types default to `FULL`, all other orders default to `ACK`.
+| sideEffectType    | String  | false    | `NO_SIDE_EFFECT`, `MARGIN_BUY`, `AUTO_REPAY`; default `NO_SIDE_EFFECT`.
+| timeInForce       | String  | false    | `GTC`,`IOC`,`FOK`        |
+| recvWindow        | Number  | false    | No more than 60000        |
+
+<details>
+<summary>Output</summary>
+    
+```js
+{
+  "orderListId": 45514668,
+  "contingencyType": 'OCO',
+  "listStatusType": 'EXEC_STARTED',
+  "listOrderStatus": 'EXECUTING',
+  "listClientOrderId": 'CD9UzEJfmcGZ4kLfZT2ga2',
+  "transactionTime": 1632192162785,
+  "symbol": 'AUDIOUSDT',
+  "isIsolated": true,
+  "orders": [
+    {
+      "symbol": 'AUDIOUSDT',
+      "orderId": 239313661,
+      "clientOrderId": 'ZbUwgKv6UB8eMzf2yfXENl'
+    },
+    {
+      "symbol": 'AUDIOUSDT',
+      "orderId": 239313662,
+      "clientOrderId": 'f5u1RIHAPRd4W3fFhFykBo'
+    }
+  ],
+  "orderReports": [
+    {
+      "symbol": 'AUDIOUSDT',
+      "orderId": 239313661,
+      "orderListId": 45514668,
+      "clientOrderId": 'ZbUwgKv6UB8eMzf2yfXENl',
+      "transactTime": 1632192162785,
+      "price": '2.20000000',
+      "origQty": '12.80000000',
+      "executedQty": '0',
+      "cummulativeQuoteQty": '0',
+      "status": 'NEW',
+      "timeInForce": 'GTC',
+      "type": 'STOP_LOSS_LIMIT',
+      "side": 'SELL',
+      "stopPrice": '2.20000000'
+    },
+    {
+      "symbol": 'AUDIOUSDT',
+      "orderId": 239313662,
+      "orderListId": 45514668,
+      "clientOrderId": 'f5u1RIHAPRd4W3fFhFykBo',
+      "transactTime": 1632192162785,
+      "price": '2.50000000',
+      "origQty": '12.80000000',
+      "executedQty": '0',
+      "cummulativeQuoteQty": '0',
+      "status": 'NEW',
+      "timeInForce": 'GTC',
+      "type": 'LIMIT_MAKER',
+      "side": 'SELL'
     }
   ]
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -592,6 +592,9 @@ declare module 'binance-api-node' {
       limit?: number
       fromId?: number
     }): Promise<MyTrade[]>
+    disableMarginAccount(options: {
+      symbol: string,
+    }): Promise<{ success: boolean, symbol: string }>
   }
 
   export interface HttpError extends Error {

--- a/index.d.ts
+++ b/index.d.ts
@@ -542,6 +542,7 @@ declare module 'binance-api-node' {
       recvWindow?: number
     }): Promise<FuturesIncomeResult[]>
     marginOrder(options: NewOrderMargin): Promise<Order>
+    marginOrderOco(options: NewOcoOrderMargin): Promise<MarginOcoOrder>
     marginGetOrder(options: {
       symbol: string
       isIsolated?: string | boolean
@@ -924,6 +925,10 @@ declare module 'binance-api-node' {
   export type NewOrderSpot = NewOrderMarketBase | NewOrderMarketQuote | NewOrderLimit | NewOrderSL
 
   export type NewOrderMargin = NewOrderSpot & NewMarginOrderParent
+
+  export type NewOcoOrderMargin = NewOrderSpot & NewOcoOrder & NewMarginOrderParent & {}
+
+  export type MarginOcoOrder = OcoOrder & { isIsolated?: 'TRUE' | 'FALSE' | boolean }
 
   export type SideEffectType_LT = 'NO_SIDE_EFFECT' | 'MARGIN_BUY' | 'AUTO_REPAY'
 

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -407,6 +407,8 @@ export default opts => {
       privCall('/sapi/v1/margin/isolated/transfer', payload, 'POST'),
     marginIsolatedTransferHistory: payload =>
       privCall('/sapi/v1/margin/isolated/transfer', payload),
+    disableMarginAccount: payload =>
+      privCall('/sapi/v1/margin/isolated/account', payload, 'DELETE'),
 
     futuresPing: () => pubCall('/fapi/v1/ping').then(() => true),
     futuresTime: () => pubCall('/fapi/v1/time').then(r => r.serverTime),

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -390,6 +390,7 @@ export default opts => {
 
     marginAllOrders: payload => privCall('/sapi/v1/margin/allOrders', payload),
     marginOrder: payload => order(privCall, payload, '/sapi/v1/margin/order'),
+    marginOrderOco: payload => _orderOco(privCall, payload, '/sapi/v1/margin/order/oco'),
     marginGetOrder: payload => privCall('/sapi/v1/margin/order', payload),
     marginCancelOrder: payload => privCall('/sapi/v1/margin/order', payload, 'DELETE'),
     marginOpenOrders: payload => privCall('/sapi/v1/margin/openOrders', payload),


### PR DESCRIPTION
Binance limited the count of margin isolated trading pair, so we need to make inactive the pair after use.

`https://binance-docs.github.io/apidocs/spot/en/#disable-isolated-margin-account-trade`

`disableMarginAccount` method is using the above api.