### PR TITLE
fix interface NewFuturesOrderprice

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -873,10 +873,10 @@ declare module 'binance-api-node' {
     type: OrderType_LT
     quantity?: string
     reduceOnly?: 'true' | 'false'
-    price?: number
+    price?: string
     timeInForce?: TimeInForce_LT
     newClientOrderId?: string
-    stopPrice?: number
+    stopPrice?: string
     closePosition?: 'true' | 'false'
     activationPrice?: number
     callbackRate?: number


### PR DESCRIPTION
fix interface NewFuturesOrderprice
fis type for filed price and stopPrice
all fields with the DECIMAL type in the Binance api must be string
all fields with the LONG type in the Binance api must be number