### PR TITLE
Allow user to listen to close event (even if ws will reconnect)

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -629,6 +629,10 @@ const userOpenHandler = (cb, transform = true) => () => {
   cb({ [transform ? 'eventType' : 'type']: 'open' })
 }
 
+const userCloseHandler = (cb, transform = true) => () => {
+  cb({ [transform ? 'eventType' : 'type']: 'close' })
+}
+
 const userErrorHandler = (cb, transform = true) => error => {
   cb({ [transform ? 'eventType' : 'type']: 'error', error })
 }
@@ -712,6 +716,9 @@ const user = (opts, variator) => (cb, transform) => {
           w.onmessage = msg => userEventHandler(cb, transform, variator)(msg)
           if (opts.emitSocketOpens) {
             w.onopen = () => userOpenHandler(cb, transform)()
+          }
+          if (opts.emitSocketCloses) {
+            w.onclose = () => userCloseHandler(cb, transform)()
           }
           if (opts.emitSocketErrors) {
             w.onerror = ({ error }) => errorHandler(error)


### PR DESCRIPTION
When the websocket disconnects - the user should have the ability to act upon this if desired as there could be considerable time before a reconnection occurs.

Allow `onclose` event to be emitted similar to `onopen` and `onerror`