### PR TITLE
Add CI action that check lint, prettier & test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  code-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run checks
+        run: yarn ci

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "test": "ava --timeout=10s -v",
     "cover": "nyc ava",
     "report": "yarn cover && nyc report --reporter=text-lcov | coveralls",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "prettier": "prettier --write '{src,test}/**/*.{ts,js}'",
+    "prettier:check": "prettier -l '{src,test}/**/*.{ts,js}'",
+    "ci": "yarn lint && yarn prettier:check && yarn test"
   },
   "dependencies": {
     "https-proxy-agent": "^5.0.0",

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,4 +1,4 @@
-import http from 'http';
+import http from 'http'
 
 export const checkFields = (t, object, fields) => {
   fields.forEach(field => {
@@ -7,20 +7,18 @@ export const checkFields = (t, object, fields) => {
 }
 
 const generatePort = (() => {
-  let portNum = 9000;
-  return () => portNum++;
+  let portNum = 9000
+  return () => portNum++
 })()
 
-export const createHttpServer = (requestHandler) => {
-  const server = http.createServer(requestHandler);
-  const port = generatePort();
+export const createHttpServer = requestHandler => {
+  const server = http.createServer(requestHandler)
+  const port = generatePort()
   return {
     url: `http://127.0.0.1:${port}`,
-    start: () => new Promise((resolve, reject) =>
-      server.listen(port, err => err ? reject(err) : resolve())
-    ),
-    stop: () => new Promise((resolve, reject) =>
-      server.close(err => err ? reject(err) : resolve())
-    ),
+    start: () =>
+      new Promise((resolve, reject) => server.listen(port, err => (err ? reject(err) : resolve()))),
+    stop: () =>
+      new Promise((resolve, reject) => server.close(err => (err ? reject(err) : resolve()))),
   }
 }


### PR DESCRIPTION
Thanks a lot for this package I use it everyday that's so cool to be able to fetch binance api directly with node.

This PR adds a GitHub action that will automatically check lint/prettier/tests on every PR + on merge on `master` branch.

**nb** The `prettier` version in dependency is still `1.9*` while latest prettier is now around `2.6.*`, so I had to use old syntax with pattern matching when running prettier. Would advise to update so you can directly run on `.`

**nb2** Prettified this little `test/utils.js`