### PR TITLE
fix(deposit-history): fix request for depositoHistory

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -552,12 +552,13 @@ declare module 'binance-api-node' {
       limit?: number
     }): Promise<WithdrawHistoryResponse>
     depositHistory(options: {
-      coin: string
+      coin?: string
       status?: number
       startTime?: number
       endTime?: number
       offset?: number
       limit?: number
+      recvWindow?: number
     }): Promise<DepositHistoryResponse>
     universalTransfer(options: UniversalTransfer): Promise<{ tranId: number }>
     universalTransferHistory(


### PR DESCRIPTION
- coin is not mandatory
- add recvWindow as not mandatory

Ref: https://binance-docs.github.io/apidocs/spot/en/#deposit-history-supporting-network-user_data