### PR TITLE
Add GTE_GTC as timeInForce for STOP_MARKET and TAKE_PROFIT_MARKET orders

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -236,7 +236,12 @@ const order = (privCall, payload = {}, url) => {
       ? { timeInForce: 'GTC', ...payload }
       : payload
 
+  if (['STOP_MARKET', 'TAKE_PROFIT_MARKET'].includes(newPayload.type)) {
+    newPayload.timeInForce = "GTE_GTC"
+  }
+
   const requires = ['symbol', 'side']
+  
 
   if (
     !(newPayload.type === 'MARKET' && newPayload.quoteOrderQty) &&


### PR DESCRIPTION
There was an issue when we create both STOP_MARKET and TAKE_PROFIT_MARKET for an opened position. When one is trigerred, second order is still active. GTE_GTC allow orders to be removed if their status become "EXPIRED"