### PR TITLE
add: futuresCancelBatchOrders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 
 .env
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@ node_modules/
 dist/
 
 .env
-.idea
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 
 .env
 .idea
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -3095,6 +3095,16 @@ console.log(
 ```
 </details>
 
+#### futuresBatchOrders
+
+Place multiple orders
+
+| Name                  | Type   | Mandatory | Description                                                                               |
+|-----------------------|--------|-----------|-------------------------------------------------------------------------------------------|
+| batchOrders           | LIST   | YES       | order list. Max 5 orders                                                                             |
+
+
+
 #### futuresCancelBatchOrders
 
 Cancel multiple orders

--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ Following examples will use the `await` form, which requires some configuration 
 - [Portfolio Margin](#portfolio-margin)
   - [getPortfolioMarginAccountInfo](#getPortfolioMarginAccountInfo)
 - [Futures Authenticated REST Endpoints](#futures-authenticated-rest-endpoints)
+  - [futuresBatchOrders](#futuresBatchOrders)
   - [futuresGetOrder](#futuresGetOrder)
-  - [futuresAllOrders](#futuresAllOrders)
+  - [futuresCancelBatchOrders](#futuresCancelBatchOrders)
   - [futuresAccountBalance](#futuresAccountBalance)
   - [futuresUserTrades](#futuresUserTrades)
   - [futuresLeverageBracket](#futuresLeverageBracket)
@@ -3093,6 +3094,16 @@ console.log(
 ]
 ```
 </details>
+
+#### futuresCancelBatchOrders
+
+Cancel multiple orders
+
+| Name                  | Type   | Mandatory | Description                                                                               |
+|-----------------------|--------|-----------|-------------------------------------------------------------------------------------------|
+| symbol                | STRING | YES       | The pair name                                                                             |
+| orderIdList           | STRING | NO        | max length 10<br/>e.g. `'[1234567,2345678]'`                                                |
+| origClientOrderIdList | STRING | NO        | max length 10<br/> e.g. `'["my_id_1","my_id_2"]'`, encode the double quotes. No space after comma. |
 
 
 #### futuresLeverage

--- a/index.d.ts
+++ b/index.d.ts
@@ -607,7 +607,11 @@ declare module 'binance-api-node' {
       limit?: number
     }): Promise<FundingRateResult[]>
     futuresOrder(options: NewFuturesOrder): Promise<FuturesOrder>
-
+    futuresBatchOrders(options: {
+      batchOrders: NewFuturesOrder[]
+      recvWindow?: number
+      timestamp?: number
+    }): Promise<FuturesOrder[]>
     getMultiAssetsMargin(): Promise<MultiAssetsMargin>
     setMultiAssetsMargin(options: MultiAssetsMargin): Promise<MultiAssetsMargin>
 
@@ -619,6 +623,13 @@ declare module 'binance-api-node' {
     futuresCancelAllOpenOrders(options: {
       symbol: string
     }): Promise<FuturesCancelAllOpenOrdersResult>
+    futuresCancelBatchOrders(options: {
+      symbol: string
+      orderIdList?: number[]
+      origClientOrderIdList?: string[]
+      recvWindow?: number
+      timestamp?: number
+    })
     futuresGetOrder(options: {
       symbol: string
       orderId?: number

--- a/index.d.ts
+++ b/index.d.ts
@@ -625,8 +625,8 @@ declare module 'binance-api-node' {
     }): Promise<FuturesCancelAllOpenOrdersResult>
     futuresCancelBatchOrders(options: {
       symbol: string
-      orderIdList?: number[]
-      origClientOrderIdList?: string[]
+      orderIdList?: string
+      origClientOrderIdList?: string
       recvWindow?: number
       timestamp?: number
     })

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -448,6 +448,7 @@ export default opts => {
     futuresGetOrder: payload => privCall('/fapi/v1/order', payload),
     futuresCancelOrder: payload => privCall('/fapi/v1/order', payload, 'DELETE'),
     futuresCancelAllOpenOrders: payload => privCall('/fapi/v1/allOpenOrders', payload, 'DELETE'),
+    futuresCancelBatchOrders: payload => privCall('/fapi/v1/batchOrders', payload, 'DELETE'),
     futuresOpenOrders: payload => privCall('/fapi/v1/openOrders', payload),
     futuresAllOrders: payload => privCall('/fapi/v1/allOrders', payload),
     futuresPositionRisk: payload => privCall('/fapi/v2/positionRisk', payload),


### PR DESCRIPTION
Implements 'Cancel Multiple Orders' https://binance-docs.github.io/apidocs/futures/en/#cancel-multiple-orders-trade.

Also includes missing 'futuresBatchOrders' typings definition.