### PR TITLE
Remove symbol from GetOrderOcoOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -312,8 +312,8 @@ declare module 'binance-api-node' {
       }
 
   export type GetOrderOcoOptions =
-    | { symbol: string; orderListId: number; useServerTime?: boolean }
-    | { symbol: string; listClientOrderId: string; useServerTime?: boolean }
+    | { orderListId: number; useServerTime?: boolean }
+    | { listClientOrderId: string; useServerTime?: boolean }
 
   export type CancelOrderOcoOptions =
     | { symbol: string; orderListId: number; useServerTime?: boolean; newClientOrderId?: string }


### PR DESCRIPTION
GetOrderOptions has a `symbol` property that is converted as queryParam when requesting Binance API.
The API documentation states that `symbol` is not part of the valid parameters.
Since this property is mandatory on the type definition and Binance rejects the request with an error, this makes it impossible to use this method on applications.

<img width="849" alt="image" src="https://user-images.githubusercontent.com/18113691/183764563-06c286e9-faab-458c-91d0-86040e4c4ab3.png">


Therefore I'm removing this property from the type definition. 
Tested locally.