### PR TITLE
fix: existing tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -937,5 +937,5 @@ test('[DELIVERY-REST] aggTrades', async t => {
 test('[DELIVERY-REST] fundingRate', async t => {
   const fundingRate = await client.deliveryFundingRate({ symbol: 'TRXUSD_perp' })
   checkFields(t, fundingRate[0], ['symbol', 'fundingTime', 'fundingRate'])
-  t.is(fundingRate.length, 100)
+  t.assert(fundingRate.length >= 100)
 })


### PR DESCRIPTION
```js
❯ npm run test                                     
Found existing alias for "npm run". You should use: "npmR"

> binance-api-node@0.13.0 test
> ava --timeout=10s -v


Browserslist: browsers data (caniuse-lite) is 8 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Browserslist: browsers data (caniuse-lite) is 8 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
  ✔ auth › [AUTH] ⚠️ Skipping tests.
    ℹ Provide an API_KEY and API_SECRET to run them.
  - index › [WS] liquidations
  - index › [FUTURES-WS] all liquidations
  - index › [FUTURES-REST] allForceOrders
  ✔ index › [MISC] Some error codes are defined
  ✔ index › [WS] userEvents
  ✔ index › [REST] Signed call without creds
  ✔ index › [REST] Signed call without creds - attempt getting tradeFee
  ✔ index › [REST] Server-side JSON error
  ✔ index › [REST] Server-side HTML error
  ✔ index › [REST] ping (819ms)
  ✔ index › [REST] time (797ms)
  ✔ index › [REST] candles (836ms)
  ✔ index › [REST] book (881ms)
  ✔ index › [FUTURES-REST] time (939ms)
  ✔ index › [FUTURES-REST] ping (941ms)
  ✔ index › [FUTURES-REST] book (1s)
  ✔ index › [FUTURES-REST] markPrice (1s)
  ✔ index › [FUTURES-REST] exchangeInfo (1s)
  ✔ index › [REST] exchangeInfo (1.4s)
  ✔ index › [DELIVERY-REST] ping (1.4s)
  ✔ index › [DELIVERY-REST] time (1.4s)
  ✔ index › [DELIVERY-REST] markPrice (1.4s)
  ✔ index › [DELIVERY-REST] book (1.4s)
  ✔ index › [DELIVERY-REST] exchangeInfo (1.4s)
  ✔ index › [DELIVERY-REST] mark price candles (1.7s)
  ✔ index › [DELIVERY-REST] index price candles (1.7s)
  ✔ index › [DELIVERY-REST] trades (1.7s)
  ✔ index › [DELIVERY-REST] dailyStats (1.7s)
  ✔ index › [REST] avgPrice (1.8s)
  ✔ index › [REST] dailyStats (1.8s)
  ✔ index › [DELIVERY-REST] candles (1.9s)
  ✔ index › [REST] trades (1.9s)
  ✔ index › [REST] aggTrades (1.9s)
  ✔ index › [DELIVERY-REST] prices (1.9s)
  ✔ index › [REST] prices (1.9s)
  ✔ index › [DELIVERY-REST] allBookTickers (1.9s)
  ✔ index › [DELIVERY-REST] aggTrades (1.9s)
  ✔ index › [DELIVERY-REST] fundingRate (2s)
  ✔ index › [FUTURES-REST] dailyStats (2s)
  ✔ index › [FUTURES-REST] mark price candles (2.1s)
  ✔ index › [FUTURES-REST] trades (2.1s)
  ✔ index › [FUTURES-REST] index price candles (2.1s)
  ✔ index › [FUTURES-REST] candles (2.1s)
  ✔ index › [WS] partial depth with update speed (2.2s)
  ✔ index › [WS] depth with update speed (2.2s)
  ✔ index › [WS] partial depth (2.4s)
  ✔ index › [WS] ticker (2.4s)
  ✔ index › [WS] depth (2.4s)
  ✔ index › [WS] allMiniTickers (2.5s)
  ✔ index › [REST] individual price (2.7s)
  ✔ index › [REST] allBookTickers (2.9s)
  ✔ index › [FUTURES-REST] prices (3s)
  ✔ index › [FUTURES-REST] fundingRate (3s)
  ✔ index › [FUTURES-REST] allBookTickers (3s)
  ✔ index › [FUTURES-REST] aggTrades (3s)
  ✔ index › [WS] allTicker (3.2s)
  ✔ index › [WS] aggregate trades (8.5s)
  ✔ index › [WS] trades (8.5s)
  ✔ index › [WS] candles (10.4s)
  ✔ index › [WS] miniTicker (13.4s)
  ─

  58 tests passed
  3 tests skipped
  ```