### PR TITLE
fix(futuresLeverageBracket): symbol not required

### DIFF
--- a/types/futures.d.ts
+++ b/types/futures.d.ts
@@ -399,7 +399,7 @@ export interface FuturesEndpoints extends BinanceRestClient {
     unrealizedPnl: string;
     marginLevel: string;
   }>>;
-  futuresLeverageBracket(payload: { symbol: string }): Promise<Array<{
+  futuresLeverageBracket(payload: { symbol?: string }): Promise<Array<{
     symbol: string;
     brackets: Array<{
       bracket: number;


### PR DESCRIPTION
- relates to https://github.com/ccxt/binance-api-node/issues/691